### PR TITLE
Windows pause fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 jobs:
   allow_failures:
-    - os: windows # This should be removed once tests pass on Windows. 
+  # - os: windows # This should be removed once tests pass on Windows. 
   include:
     - os: linux
       dist: xenial
       language: python
-      python: 3.6
+      python: 3.7
       before_script:
         - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter"
         - "chmod +x ./cc-test-reporter"
@@ -16,17 +16,17 @@ jobs:
     - os: linux
       dist: bionic
       language: python
-      python: 3.6
+      python: 3.7
     - os: osx
       osx_image: xcode9.4   # Python 3.6.5 running on macOS 10.13
       language: shell       # 'language: python' is an error on Travis CI macOS
     - os: windows
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
-        - choco install python --version 3.6.0
+        - choco install python --version 3.7.0
         - choco install make
         - python -m pip install --upgrade pip
-      env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 install:
   - pip3 install --upgrade pip           
   - pip3 install -r requirements.txt

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -218,28 +218,58 @@ class SSACSolver(GillesPySolver):
                     else:
                         raise gillespyError.ModelError("seed must be a positive integer")
 
-            # begin subprocess c simulation with timeout (default timeout=0 will not timeout)
-            with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
-                return_code = 0
-                try:
-                    if timeout > 0:
-                        stdout, stderr = simulation.communicate(timeout=timeout)
-                    else:
-                        stdout, stderr = simulation.communicate()
-                    return_code = simulation.wait()
-                except KeyboardInterrupt:
-                    os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                    stdout, stderr = simulation.communicate()
-                    pause = True
-                    return_code = 33
-                except subprocess.TimeoutExpired:
+            if os.name == "nt":
+                import multiprocessing
+
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP) as simulation:
+                    return_code = 0
+
+                    try:
+                        # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
+                        # As a result, a keyboard event has to be handled gracefully without raising an exception.
+                        # Thus, a signal handler is used!
+                        def tmp_sighandler(sig, wig):
+                            print("PING!")
+                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
+                        prev_sighandler = signal.signal(signal.SIGINT, tmp_sighandler)
+
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+
+                        return_code = simulation.wait()
+                    except subprocess.TimeoutExpired:
+                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
+                            stdout, stderr = simulation.communicate()
+                            pause = True
+                            return_code = 33
+                    finally:
+                        # Restore the old signal handler
+                        signal.signal(signal.SIGINT, prev_sighandler)
+            else:
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
+                    return_code = 0
+                    try:
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+                        return_code = simulation.wait()
+                    except KeyboardInterrupt:
                         os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
                         stdout, stderr = simulation.communicate()
                         pause = True
                         return_code = 33
+                    except subprocess.TimeoutExpired:
+                            os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
+                            stdout, stderr = simulation.communicate()
+                            pause = True
+                            return_code = 33
 
             # Decode from byte, split by comma into array
             stdout = stdout.decode('utf-8').split(',')
+            print("Results: {}".format(len(stdout)))
             # Parse/return results
 
             if return_code in [0, 33]:

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -280,25 +280,60 @@ class VariableSSACSolver(GillesPySolver):
                         raise gillespyError.ModelError("seed must be a positive integer")
 
             # begin subprocess c simulation with timeout (default timeout=0 will not timeout)
-            with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
-                try:
-                    if timeout > 0:
-                        stdout, stderr = simulation.communicate(timeout=timeout)
-                    else:
+            if os.name == "nt":
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
+                                      creationflags=subprocess.CREATE_NEW_PROCESS_GROUP) as simulation:
+                    return_code = 0
+
+                    try:
+                        # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
+                        # As a result, a keyboard event has to be handled gracefully without raising an exception.
+                        # Thus, a signal handler is used!
+                        def tmp_sighandler(sig, stack):
+                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
+
+                        prev_sighandler = signal.signal(signal.SIGINT, tmp_sighandler)
+
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+
+                        return_code = simulation.wait()
+                    except subprocess.TimeoutExpired:
+                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
                         stdout, stderr = simulation.communicate()
-                    return_code = simulation.wait()
-                except KeyboardInterrupt:
-                    os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                    stdout, stderr = simulation.communicate()
-                    pause = True
-                    return_code = 33
-                except subprocess.TimeoutExpired:
-                    os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                    stdout, stderr = simulation.communicate()
-                    pause = True
-                    return_code = 33
-            # Decode from byte, split by comma into array
-            stdout = stdout.decode('utf-8').split(',')
+                        pause = True
+                        return_code = 33
+                    finally:
+                        # Restore the old signal handler
+                        signal.signal(signal.SIGINT, prev_sighandler)
+                        # Decode from byte, split by comma into array
+                        stdout = stdout.decode('utf-8').split(',')
+                        # Check if the simulation had been paused
+                        # (Necessary because we can't set pause to True from signal handler)
+                        if int(stdout[-1]) != round(t):
+                            pause = True
+            else:
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
+                    try:
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+                        return_code = simulation.wait()
+                    except KeyboardInterrupt:
+                        os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
+                        stdout, stderr = simulation.communicate()
+                        pause = True
+                        return_code = 33
+                    except subprocess.TimeoutExpired:
+                        os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
+                        stdout, stderr = simulation.communicate()
+                        pause = True
+                        return_code = 33
+                # Decode from byte, split by comma into array
+                stdout = stdout.decode('utf-8').split(',')
             # Parse/return results.
 
             if return_code in [0, 33]:

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -58,14 +58,17 @@ class TestPauseResume(unittest.TestCase):
 
     def test_pause(self):
         py_path = which('python3')
-        model_path = os.path.join(os.getcwd(), 'pause_model.py')
+        model_path = os.path.join(os.path.dirname(__file__), 'pause_model.py')
         args = [[py_path, model_path, 'NumPySSASolver'],
                 [py_path, model_path, 'TauLeapingSolver'],
                 [py_path, model_path, 'ODESolver']]
         for arg in args:
             p = subprocess.Popen(arg, start_new_session=True, stdout=subprocess.PIPE)
             time.sleep(2)
-            os.kill(p.pid, signal.SIGINT)
+            if os.name == 'nt':
+                p.send_signal(signal.CTRL_C_EVENT)
+            else:
+                os.kill(p.pid, signal.SIGINT)
             out, err = p.communicate()
             # End time for Oregonator is 5. If indexing into a numpy array using the form:
             # results[0][-1][0] (where .run(show_labels=False), this index being the last time in the index

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 import subprocess
+from shutil import which
 from example_models import MichaelisMenten, Oregonator
 from gillespy2.core.results import Results, Trajectory
 from gillespy2.core import Species
@@ -56,8 +57,11 @@ class TestPauseResume(unittest.TestCase):
                                                  t=1)
 
     def test_pause(self):
-        args = [['python3', 'pause_model.py', 'NumPySSASolver'], ['python3', 'pause_model.py', 'TauLeapingSolver'],
-                ['python3', 'pause_model.py', 'ODESolver']]
+        py_path = which('python3')
+        model_path = os.path.join(os.getcwd(), 'pause_model.py')
+        args = [[py_path, model_path, 'NumPySSASolver'],
+                [py_path, model_path, 'TauLeapingSolver'],
+                [py_path, model_path, 'ODESolver']]
         for arg in args:
             p = subprocess.Popen(arg, start_new_session=True, stdout=subprocess.PIPE)
             time.sleep(2)

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -58,6 +58,8 @@ class TestPauseResume(unittest.TestCase):
 
     def test_pause(self):
         py_path = which('python3')
+        if py_path is None:
+            py_path = which('python')
         model_path = os.path.join(os.path.dirname(__file__), 'pause_model.py')
         args = [[py_path, model_path, 'NumPySSASolver'],
                 [py_path, model_path, 'TauLeapingSolver'],


### PR DESCRIPTION
Replaces the `os.killpg` call in the C solvers with a platform-specific solution on Windows. A signal handler is attached to prevent Windows from breaking the pipe to stdout when a KeyboardInterrupt is raised.

Closes #480, Closes #426 