### PR TITLE
Windows pause fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ jobs:
         - choco install make
         - choco install mingw
         - python -m pip install --upgrade pip
+        - python -m pip install certifi
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 install:
   - pip3 install --upgrade pip           

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ jobs:
       before_install:
         - choco install python --version 3.7.0
         - choco install make
+        - choco install mingw
         - python -m pip install --upgrade pip
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 jobs:
   allow_failures:
-    - os: windows # This should be removed once tests pass on Windows. 
+  # - os: windows # This should be removed once tests pass on Windows. 
   include:
     - os: linux
       dist: xenial
       language: python
-      python: 3.6
+      python: 3.7
       before_script:
         - "curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter"
         - "chmod +x ./cc-test-reporter"
@@ -16,17 +16,17 @@ jobs:
     - os: linux
       dist: bionic
       language: python
-      python: 3.6
+      python: 3.7
     - os: osx
       osx_image: xcode9.4   # Python 3.6.5 running on macOS 10.13
       language: shell       # 'language: python' is an error on Travis CI macOS
     - os: windows
       language: shell       # 'language: python' is an error on Travis CI Windows
       before_install:
-        - choco install python --version 3.6.0
+        - choco install python --version 3.7.0
         - choco install make
         - python -m pip install --upgrade pip
-      env: PATH=/c/Python36:/c/Python36/Scripts:$PATH
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 install:
   - pip3 install --upgrade pip           
   - pip3 install -r requirements.txt

--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -858,17 +858,6 @@ class Model(SortableObject):
                 results = results.to_array()
             return results
 
-        if len(solver_results) > 0:
-            results_list = []
-            for i in range(0, len(solver_results)):
-                temp = Trajectory(data=solver_results[i], model=self, solver_name=solver.name, rc=rc)
-                results_list.append(temp)
-
-            results = Results(results_list)
-            if show_labels == False:
-                results = results.to_array()
-            return results
-
         else:
             raise ValueError("number_of_trajectories must be non-negative and non-zero")
 

--- a/gillespy2/solvers/cpp/c_base/ssa.cpp
+++ b/gillespy2/solvers/cpp/c_base/ssa.cpp
@@ -4,16 +4,31 @@
 #include <string.h>//Included for memcpy only
 #include <csignal>//Included for timeout signal handling
 
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 namespace Gillespy{
 
-  bool interrupted = false ;
+  volatile bool interrupted = false ;
+
+  #ifdef _WIN32
+  BOOL WINAPI eventHandler(DWORD CtrlType) {
+    interrupted = true;
+    return TRUE;
+  }
+  #endif
 
   void signalHandler( int signum){
     interrupted = true ;
   }
 
   void ssa_direct(Simulation* simulation){
-    signal(SIGINT, signalHandler) ;
+    #ifdef _WIN32
+    SetConsoleCtrlHandler(eventHandler, TRUE);
+    #else
+    signal(SIGINT, signalHandler);
+    #endif
 
     if(simulation){
       std :: mt19937_64 rng(simulation -> random_seed);

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -231,14 +231,8 @@ class SSACSolver(GillesPySolver):
                         sim_buffer.append(line)
                     return ln
                 # Read output 1 block at a time, until the program is finished.
-                page_size = 0
-                while sim.poll() is None:
-                    page_size = read_next()
-                    if page_size == 0:
-                        break
-                # Keep reading from the output buffer until there's nothing left.
-                # Necessary because it's possible for there to be leftover data in the buffer.
-                while page_size > 0:
+                page_size = read_next()
+                while page_size > 0 and sim.poll() is None:
                     page_size = read_next()
 
             # Buffer to store the output of the simulation (retrieved from sim_delegate thread).

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -220,62 +220,54 @@ class SSACSolver(GillesPySolver):
                     else:
                         raise gillespyError.ModelError("seed must be a positive integer")
 
+            # Handler for reading data from subprocess, in background thread.
+            def sim_delegate(sim, sim_buffer):
+                def read_next():
+                    # Reads the next block from the simulation output.
+                    # Returns the length of the string read.
+                    line = sim.stdout.read().decode("utf-8")
+                    ln = len(line)
+                    if ln > 0:
+                        sim_buffer.append(line)
+                    return ln
+                # Read output 1 block at a time, until the program is finished.
+                page_size = 0
+                while sim.poll() is None:
+                    page_size = read_next()
+                    if page_size == 0:
+                        break
+                # Keep reading from the output buffer until there's nothing left.
+                # Necessary because it's possible for there to be leftover data in the buffer.
+                while page_size > 0:
+                    page_size = read_next()
+
+            # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
+            buffer = []
             # Windows event handling
+            # Each platform is given their own platform-specific sub_kill() function.
+            thread_events = { "timeout": False }
             if os.name == "nt":
+                sub_kill = lambda sim: sim.send_signal(signal.CTRL_BREAK_EVENT)
                 simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
                                               creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
             # POSIX event handling
             else:
+                sub_kill = lambda sim: os.killpg(sim.pid, signal.SIGINT)
                 simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True)
-            return_code = 0
+            output_process = threading.Thread(name="SimulationHandlerThread",
+                                                target=sim_delegate,
+                                                args=(simulation, buffer))
 
             with simulation:
-                # Handler for reading data from subprocess, in background thread.
-                def sim_delegate(sim_buffer):
-                    def read_next():
-                        # Reads the next block from the simulation output.
-                        # Returns the length of the string read.
-                        line = simulation.stdout.read(8192).decode("utf-8").strip()
-                        ln = len(line)
-                        if ln > 0:
-                            sim_buffer.append(line)
-                        return ln
-                    # Read output 1 block at a time, until the program is finished.
-                    page_size = 0
-                    while simulation.poll() is None:
-                        page_size = read_next()
-                        if page_size == 0:
-                            break
-                    # Keep reading from the output buffer until there's nothing left.
-                    # Necessary because it's possible for there to be leftover data in the buffer.
-                    while page_size > 0:
-                        page_size = read_next()
+                return_code = 0
+                output_process.start()
 
-                def sub_kill():
-                    # Sends platform-specific signals to the simulation process.
-                    if os.name == "nt":
-                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                    else:
-                        os.killpg(simulation.pid, signal.SIGINT) # send signal to the process group
-
-                # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
-                buffer = []
-                output_process = threading.Thread(name="SimulationHandlerThread",
-                                                    target=sim_delegate,
-                                                    args=(buffer,))
+                # Put a timer on in the background, if a timeout was specified.
+                def timeout_kill():
+                    thread_events["timeout"] = True
+                    sub_kill(simulation)
 
                 try:
-                    # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
-                    # As a result, a keyboard event has to be handled gracefully without raising an exception.
-                    # Thus, a signal handler is used!
-                    thread_events = { "timeout": False }
-                    output_process.start()
-
-                    # Put a timer on in the background, if a timeout was specified.
-                    def timeout_kill():
-                        thread_events["timeout"] = True
-                        sub_kill()
-
                     timeout_thread = threading.Timer(timeout, timeout_kill)
                     if timeout > 0:
                         timeout_thread.start()
@@ -284,7 +276,7 @@ class SSACSolver(GillesPySolver):
                     while simulation.poll() is None:
                         time.sleep(0.1)
                 except KeyboardInterrupt:
-                    sub_kill()
+                    sub_kill(simulation)
                     pause = True
                     return_code = 33
                 finally:
@@ -292,7 +284,7 @@ class SSACSolver(GillesPySolver):
                     return_code = simulation.wait()
                     output_process.join()
                     if timeout_thread.is_alive():
-                        timeout_thread.join()
+                        timeout_thread.cancel()
 
                     # Decode from byte, split by comma into array
                     stdout = "".join(buffer).split(",")

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -256,10 +256,12 @@ class SSACSolver(GillesPySolver):
                         # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
                         # As a result, a keyboard event has to be handled gracefully without raising an exception.
                         # Thus, a signal handler is used!
+                        thread_events = { "timeout": False }
                         output_process.start()
 
                         # Put a timer on in the background, if a timeout was specified.
                         def timeout_kill():
+                            thread_events["timeout"] = True
                             simulation.send_signal(signal.CTRL_BREAK_EVENT)
                         timeout_thread = threading.Timer(timeout, timeout_kill)
                         if timeout > 0:
@@ -284,7 +286,7 @@ class SSACSolver(GillesPySolver):
                         stdout = "".join(buffer).split(",")
                         # Check if the simulation had been paused
                         # (Necessary because we can't set pause to True from thread handler)
-                        if int(stdout[-1]) != round(t):
+                        if thread_events["timeout"]:
                             pause = True
                             return_code = 33
             # POSIX event handling

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -4,6 +4,7 @@ from gillespy2.solvers.utilities import solverutils as cutils
 import signal, time #for solver timeout implementation
 import os #for getting directories for C++ files
 import shutil #for deleting/copying files
+import threading # for handling read/write to simulation in the background
 import subprocess #For calling make and executing c solver
 import inspect #for finding the Gillespy2 module path
 import tempfile #for temporary directories
@@ -225,34 +226,54 @@ class SSACSolver(GillesPySolver):
                                       creationflags=subprocess.CREATE_NEW_PROCESS_GROUP) as simulation:
                     return_code = 0
 
+                    # Handler for reading data from subprocess, in background thread.
+                    def sim_delegate(sim_buffer):
+                        # Read output 1kb at a time, until the program is finished.
+                        while simulation.poll() is None:
+                            line = simulation.stdout.read(1024).decode("utf-8")
+                            if len(line) > 1:
+                                sim_buffer.append(line)
+
+                    # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
+                    buffer = []
+                    output_process = threading.Thread(name="SimulationHandlerThread",
+                                                      target=sim_delegate,
+                                                      args=(buffer,))
+
                     try:
                         # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
                         # As a result, a keyboard event has to be handled gracefully without raising an exception.
                         # Thus, a signal handler is used!
-                        def tmp_sighandler(sig, stack):
+                        output_process.start()
+
+                        # Put a timer on in the background, if a timeout was specified.
+                        def timeout_kill():
                             simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                        prev_sighandler = signal.signal(signal.SIGINT, tmp_sighandler)
-
+                        timeout_thread = threading.Timer(timeout, timeout_kill)
                         if timeout > 0:
-                            stdout, stderr = simulation.communicate(timeout=timeout)
-                        else:
-                            stdout, stderr = simulation.communicate()
+                            timeout_thread.start()
 
+                        # Poll for the program's status; keyboard interrupt is ignored if we use .wait()
+                        while simulation.poll() is None:
+                            time.sleep(0.1)
                         return_code = simulation.wait()
-                    except subprocess.TimeoutExpired:
+                    except KeyboardInterrupt:
                         simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                        stdout, stderr = simulation.communicate()
                         pause = True
                         return_code = 33
                     finally:
-                        # Restore the old signal handler
-                        signal.signal(signal.SIGINT, prev_sighandler)
+                        # Finish off the output reader thread and the timer thread.
+                        output_process.join()
+                        if timeout_thread.is_alive():
+                            timeout_thread.join()
+
                         # Decode from byte, split by comma into array
-                        stdout = stdout.decode('utf-8').split(',')
+                        stdout = "".join(buffer).split(",")
                         # Check if the simulation had been paused
-                        # (Necessary because we can't set pause to True from signal handler)
+                        # (Necessary because we can't set pause to True from thread handler)
                         if int(stdout[-1]) != round(t):
                             pause = True
+                            return_code = 33
             # POSIX event handling
             else:
                 with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -218,28 +218,58 @@ class SSACSolver(GillesPySolver):
                     else:
                         raise gillespyError.ModelError("seed must be a positive integer")
 
-            # begin subprocess c simulation with timeout (default timeout=0 will not timeout)
-            with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
-                return_code = 0
-                try:
-                    if timeout > 0:
-                        stdout, stderr = simulation.communicate(timeout=timeout)
-                    else:
-                        stdout, stderr = simulation.communicate()
-                    return_code = simulation.wait()
-                except KeyboardInterrupt:
-                    os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                    stdout, stderr = simulation.communicate()
-                    pause = True
-                    return_code = 33
-                except subprocess.TimeoutExpired:
+            if os.name == "nt":
+                import multiprocessing
+
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP) as simulation:
+                    return_code = 0
+
+                    try:
+                        # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
+                        # As a result, a keyboard event has to be handled gracefully without raising an exception.
+                        # Thus, a signal handler is used!
+                        def tmp_sighandler(sig, wig):
+                            print("PING!")
+                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
+                        prev_sighandler = signal.signal(signal.SIGINT, tmp_sighandler)
+
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+
+                        return_code = simulation.wait()
+                    except subprocess.TimeoutExpired:
+                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
+                            stdout, stderr = simulation.communicate()
+                            pause = True
+                            return_code = 33
+                    finally:
+                        # Restore the old signal handler
+                        signal.signal(signal.SIGINT, prev_sighandler)
+            else:
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
+                    return_code = 0
+                    try:
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+                        return_code = simulation.wait()
+                    except KeyboardInterrupt:
                         os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
                         stdout, stderr = simulation.communicate()
                         pause = True
                         return_code = 33
+                    except subprocess.TimeoutExpired:
+                            os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
+                            stdout, stderr = simulation.communicate()
+                            pause = True
+                            return_code = 33
 
             # Decode from byte, split by comma into array
             stdout = stdout.decode('utf-8').split(',')
+            print("Results: {}".format(len(stdout)))
             # Parse/return results
 
             if return_code in [0, 33]:

--- a/gillespy2/solvers/cpp/ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/ssa_c_solver.py
@@ -1,7 +1,8 @@
 import gillespy2
 from gillespy2.core import gillespyError, GillesPySolver, log
 from gillespy2.solvers.utilities import solverutils as cutils
-import signal, time #for solver timeout implementation
+import signal
+import time #for solver timeout implementation
 import os #for getting directories for C++ files
 import shutil #for deleting/copying files
 import threading # for handling read/write to simulation in the background
@@ -221,100 +222,85 @@ class SSACSolver(GillesPySolver):
 
             # Windows event handling
             if os.name == "nt":
-                # Windows has some issues with process groups; must be handled differently!
-                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
-                                      creationflags=subprocess.CREATE_NEW_PROCESS_GROUP) as simulation:
-                    return_code = 0
-
-                    # Handler for reading data from subprocess, in background thread.
-                    def sim_delegate(sim_buffer):
-                        def read_next():
-                            """
-                            Reads the next block from the simulation output.
-                            Returns the length of the string read.
-                            """
-                            line = simulation.stdout.read(8192).decode("utf-8").strip()
-                            ln = len(line)
-                            if ln > 0:
-                                sim_buffer.append(line)
-                            return ln
-                        # Read output 1 block at a time, until the program is finished.
-                        page_size = 0
-                        while simulation.poll() is None:
-                            page_size = read_next()
-                            if page_size == 0:
-                                break
-                        # Keep reading from the output buffer until there's nothing left.
-                        # Necessary because it's possible for there to be leftover data in the buffer.
-                        while page_size > 0:
-                            page_size = read_next()
-
-                    # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
-                    buffer = []
-                    output_process = threading.Thread(name="SimulationHandlerThread",
-                                                      target=sim_delegate,
-                                                      args=(buffer,))
-
-                    try:
-                        # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
-                        # As a result, a keyboard event has to be handled gracefully without raising an exception.
-                        # Thus, a signal handler is used!
-                        thread_events = { "timeout": False }
-                        output_process.start()
-
-                        # Put a timer on in the background, if a timeout was specified.
-                        def timeout_kill():
-                            thread_events["timeout"] = True
-                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                        timeout_thread = threading.Timer(timeout, timeout_kill)
-                        if timeout > 0:
-                            timeout_thread.start()
-
-                        # Poll for the program's status; keyboard interrupt is ignored if we use .wait()
-                        while simulation.poll() is None:
-                            time.sleep(0.1)
-                    except KeyboardInterrupt:
-                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                        pause = True
-                        return_code = 33
-                    finally:
-                        # Finish off the output reader thread and the timer thread.
-                        return_code = simulation.wait()
-                        simulation.wait()
-                        output_process.join()
-                        if timeout_thread.is_alive():
-                            timeout_thread.join()
-
-                        # Decode from byte, split by comma into array
-                        stdout = "".join(buffer).split(",")
-                        # Check if the simulation had been paused
-                        # (Necessary because we can't set pause to True from thread handler)
-                        if thread_events["timeout"]:
-                            pause = True
-                            return_code = 33
+                simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
+                                              creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
             # POSIX event handling
             else:
-                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
-                    return_code = 0
-                    try:
-                        if timeout > 0:
-                            stdout, stderr = simulation.communicate(timeout=timeout)
-                        else:
-                            stdout, stderr = simulation.communicate()
-                        return_code = simulation.wait()
-                    except KeyboardInterrupt:
-                        os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                        stdout, stderr = simulation.communicate()
+                simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True)
+            return_code = 0
+
+            with simulation:
+                # Handler for reading data from subprocess, in background thread.
+                def sim_delegate(sim_buffer):
+                    def read_next():
+                        # Reads the next block from the simulation output.
+                        # Returns the length of the string read.
+                        line = simulation.stdout.read(8192).decode("utf-8").strip()
+                        ln = len(line)
+                        if ln > 0:
+                            sim_buffer.append(line)
+                        return ln
+                    # Read output 1 block at a time, until the program is finished.
+                    page_size = 0
+                    while simulation.poll() is None:
+                        page_size = read_next()
+                        if page_size == 0:
+                            break
+                    # Keep reading from the output buffer until there's nothing left.
+                    # Necessary because it's possible for there to be leftover data in the buffer.
+                    while page_size > 0:
+                        page_size = read_next()
+
+                def sub_kill():
+                    # Sends platform-specific signals to the simulation process.
+                    if os.name == "nt":
+                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
+                    else:
+                        os.killpg(simulation.pid, signal.SIGINT) # send signal to the process group
+
+                # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
+                buffer = []
+                output_process = threading.Thread(name="SimulationHandlerThread",
+                                                    target=sim_delegate,
+                                                    args=(buffer,))
+
+                try:
+                    # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
+                    # As a result, a keyboard event has to be handled gracefully without raising an exception.
+                    # Thus, a signal handler is used!
+                    thread_events = { "timeout": False }
+                    output_process.start()
+
+                    # Put a timer on in the background, if a timeout was specified.
+                    def timeout_kill():
+                        thread_events["timeout"] = True
+                        sub_kill()
+
+                    timeout_thread = threading.Timer(timeout, timeout_kill)
+                    if timeout > 0:
+                        timeout_thread.start()
+
+                    # Poll for the program's status; keyboard interrupt is ignored if we use .wait()
+                    while simulation.poll() is None:
+                        time.sleep(0.1)
+                except KeyboardInterrupt:
+                    sub_kill()
+                    pause = True
+                    return_code = 33
+                finally:
+                    # Finish off the output reader thread and the timer thread.
+                    return_code = simulation.wait()
+                    output_process.join()
+                    if timeout_thread.is_alive():
+                        timeout_thread.join()
+
+                    # Decode from byte, split by comma into array
+                    stdout = "".join(buffer).split(",")
+                    # Check if the simulation had been paused
+                    # (Necessary because we can't set pause to True from thread handler)
+                    if thread_events["timeout"]:
                         pause = True
                         return_code = 33
-                    except subprocess.TimeoutExpired:
-                            os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                            stdout, stderr = simulation.communicate()
-                            pause = True
-                            return_code = 33
-                # Decode from byte, split by comma into array
-                stdout = stdout.decode('utf-8').split(',')
-            # Parse/return results
 
             if return_code in [0, 33]:
                 trajectory_base, timeStopped = cutils._parse_binary_output(stdout, number_of_trajectories,

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -282,62 +282,54 @@ class VariableSSACSolver(GillesPySolver):
                         raise gillespyError.ModelError("seed must be a positive integer")
 
             # begin subprocess c simulation with timeout (default timeout=0 will not timeout)
+            # Handler for reading data from subprocess, in background thread.
+            def sim_delegate(sim, sim_buffer):
+                def read_next():
+                    # Reads the next block from the simulation output.
+                    # Returns the length of the string read.
+                    line = sim.stdout.read().decode("utf-8")
+                    ln = len(line)
+                    if ln > 0:
+                        sim_buffer.append(line)
+                    return ln
+                # Read output 1 block at a time, until the program is finished.
+                page_size = 0
+                while sim.poll() is None:
+                    page_size = read_next()
+                    if page_size == 0:
+                        break
+                # Keep reading from the output buffer until there's nothing left.
+                # Necessary because it's possible for there to be leftover data in the buffer.
+                while page_size > 0:
+                    page_size = read_next()
+
+            # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
+            buffer = []
             # Windows event handling
+            # Each platform is given their own platform-specific sub_kill() function.
+            thread_events = { "timeout": False }
             if os.name == "nt":
+                sub_kill = lambda sim: sim.send_signal(signal.CTRL_BREAK_EVENT)
                 simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
                                               creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
             # POSIX event handling
             else:
+                sub_kill = lambda sim: os.killpg(sim.pid, signal.SIGINT)
                 simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True)
-            return_code = 0
+            output_process = threading.Thread(name="SimulationHandlerThread",
+                                                target=sim_delegate,
+                                                args=(simulation, buffer))
 
             with simulation:
-                # Handler for reading data from subprocess, in background thread.
-                def sim_delegate(sim_buffer):
-                    def read_next():
-                        # Reads the next block from the simulation output.
-                        # Returns the length of the string read.
-                        line = simulation.stdout.read(8192).decode("utf-8").strip()
-                        ln = len(line)
-                        if ln > 0:
-                            sim_buffer.append(line)
-                        return ln
-                    # Read output 1 block at a time, until the program is finished.
-                    page_size = 0
-                    while simulation.poll() is None:
-                        page_size = read_next()
-                        if page_size == 0:
-                            break
-                    # Keep reading from the output buffer until there's nothing left.
-                    # Necessary because it's possible for there to be leftover data in the buffer.
-                    while page_size > 0:
-                        page_size = read_next()
+                return_code = 0
+                output_process.start()
 
-                def sub_kill():
-                    # Sends platform-specific signals to the simulation process.
-                    if os.name == "nt":
-                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                    else:
-                        os.killpg(simulation.pid, signal.SIGINT) # send signal to the process group
-
-                # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
-                buffer = []
-                output_process = threading.Thread(name="SimulationHandlerThread",
-                                                    target=sim_delegate,
-                                                    args=(buffer,))
+                # Put a timer on in the background, if a timeout was specified.
+                def timeout_kill():
+                    thread_events["timeout"] = True
+                    sub_kill(simulation)
 
                 try:
-                    # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
-                    # As a result, a keyboard event has to be handled gracefully without raising an exception.
-                    # Thus, a signal handler is used!
-                    thread_events = { "timeout": False }
-                    output_process.start()
-
-                    # Put a timer on in the background, if a timeout was specified.
-                    def timeout_kill():
-                        thread_events["timeout"] = True
-                        sub_kill()
-
                     timeout_thread = threading.Timer(timeout, timeout_kill)
                     if timeout > 0:
                         timeout_thread.start()
@@ -346,7 +338,7 @@ class VariableSSACSolver(GillesPySolver):
                     while simulation.poll() is None:
                         time.sleep(0.1)
                 except KeyboardInterrupt:
-                    sub_kill()
+                    sub_kill(simulation)
                     pause = True
                     return_code = 33
                 finally:
@@ -354,7 +346,7 @@ class VariableSSACSolver(GillesPySolver):
                     return_code = simulation.wait()
                     output_process.join()
                     if timeout_thread.is_alive():
-                        timeout_thread.join()
+                        timeout_thread.cancel()
 
                     # Decode from byte, split by comma into array
                     stdout = "".join(buffer).split(",")
@@ -363,7 +355,6 @@ class VariableSSACSolver(GillesPySolver):
                     if thread_events["timeout"]:
                         pause = True
                         return_code = 33
-            # Parse/return results.
 
             if return_code in [0, 33]:
                 trajectory_base, timeStopped = cutils._parse_binary_output(stdout, number_of_trajectories,

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -1,7 +1,8 @@
 import gillespy2
 from gillespy2.core import Model, Reaction, gillespyError, GillesPySolver, log
 from gillespy2.solvers.utilities import solverutils as cutils
-import signal, time # for solver timeout implementation
+import signal
+import time # for solver timeout implementation
 import os  #for getting directories for C++ files
 import shutil #for deleting/copying files
 import threading # for handling read/write to simulation in the background
@@ -283,97 +284,85 @@ class VariableSSACSolver(GillesPySolver):
             # begin subprocess c simulation with timeout (default timeout=0 will not timeout)
             # Windows event handling
             if os.name == "nt":
-                # Windows has some issues with process groups; must be handled differently!
-                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
-                                      creationflags=subprocess.CREATE_NEW_PROCESS_GROUP) as simulation:
-                    return_code = 0
-
-                    # Handler for reading data from subprocess, in background thread.
-                    def sim_delegate(sim_buffer):
-                        def read_next():
-                            """
-                            Reads the next block from the simulation output.
-                            Returns the length of the string read.
-                            """
-                            line = simulation.stdout.read(8192).decode("utf-8").strip()
-                            ln = len(line)
-                            if ln > 0:
-                                sim_buffer.append(line)
-                            return ln
-                        # Read output 1 block at a time, until the program is finished.
-                        page_size = 0
-                        while simulation.poll() is None:
-                            page_size = read_next()
-                            if page_size == 0:
-                                break
-                        # Keep reading from the output buffer until there's nothing left.
-                        # Necessary because it's possible for there to be leftover data in the buffer.
-                        while page_size > 0:
-                            page_size = read_next()
-
-                    # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
-                    buffer = []
-                    output_process = threading.Thread(name="SimulationHandlerThread",
-                                                      target=sim_delegate,
-                                                      args=(buffer,))
-
-                    try:
-                        # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
-                        # As a result, a keyboard event has to be handled gracefully without raising an exception.
-                        # Thus, a signal handler is used!
-                        thread_events = { "timeout": False }
-                        output_process.start()
-
-                        # Put a timer on in the background, if a timeout was specified.
-                        def timeout_kill():
-                            thread_events["timeout"] = True
-                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                        timeout_thread = threading.Timer(timeout, timeout_kill)
-                        if timeout > 0:
-                            timeout_thread.start()
-
-                        # Poll for the program's status; keyboard interrupt is ignored if we use .wait()
-                        while simulation.poll() is None:
-                            time.sleep(0.1)
-                    except KeyboardInterrupt:
-                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
-                        pause = True
-                        return_code = 33
-                    finally:
-                        # Finish off the output reader thread and the timer thread.
-                        return_code = simulation.wait()
-                        output_process.join()
-                        if timeout_thread.is_alive():
-                            timeout_thread.join()
-
-                        # Decode from byte, split by comma into array
-                        stdout = "".join(buffer).split(",")
-                        # Check if the simulation had been paused
-                        # (Necessary because we can't set pause to True from thread handler)
-                        if thread_events["timeout"]:
-                            pause = True
-                            return_code = 33
+                simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
+                                              creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
             # POSIX event handling
             else:
-                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
-                    try:
-                        if timeout > 0:
-                            stdout, stderr = simulation.communicate(timeout=timeout)
-                        else:
-                            stdout, stderr = simulation.communicate()
-                        return_code = simulation.wait()
-                    except KeyboardInterrupt:
-                        os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                        stdout, stderr = simulation.communicate()
+                simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True)
+            return_code = 0
+
+            with simulation:
+                # Handler for reading data from subprocess, in background thread.
+                def sim_delegate(sim_buffer):
+                    def read_next():
+                        # Reads the next block from the simulation output.
+                        # Returns the length of the string read.
+                        line = simulation.stdout.read(8192).decode("utf-8").strip()
+                        ln = len(line)
+                        if ln > 0:
+                            sim_buffer.append(line)
+                        return ln
+                    # Read output 1 block at a time, until the program is finished.
+                    page_size = 0
+                    while simulation.poll() is None:
+                        page_size = read_next()
+                        if page_size == 0:
+                            break
+                    # Keep reading from the output buffer until there's nothing left.
+                    # Necessary because it's possible for there to be leftover data in the buffer.
+                    while page_size > 0:
+                        page_size = read_next()
+
+                def sub_kill():
+                    # Sends platform-specific signals to the simulation process.
+                    if os.name == "nt":
+                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
+                    else:
+                        os.killpg(simulation.pid, signal.SIGINT) # send signal to the process group
+
+                # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
+                buffer = []
+                output_process = threading.Thread(name="SimulationHandlerThread",
+                                                    target=sim_delegate,
+                                                    args=(buffer,))
+
+                try:
+                    # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
+                    # As a result, a keyboard event has to be handled gracefully without raising an exception.
+                    # Thus, a signal handler is used!
+                    thread_events = { "timeout": False }
+                    output_process.start()
+
+                    # Put a timer on in the background, if a timeout was specified.
+                    def timeout_kill():
+                        thread_events["timeout"] = True
+                        sub_kill()
+
+                    timeout_thread = threading.Timer(timeout, timeout_kill)
+                    if timeout > 0:
+                        timeout_thread.start()
+
+                    # Poll for the program's status; keyboard interrupt is ignored if we use .wait()
+                    while simulation.poll() is None:
+                        time.sleep(0.1)
+                except KeyboardInterrupt:
+                    sub_kill()
+                    pause = True
+                    return_code = 33
+                finally:
+                    # Finish off the output reader thread and the timer thread.
+                    return_code = simulation.wait()
+                    output_process.join()
+                    if timeout_thread.is_alive():
+                        timeout_thread.join()
+
+                    # Decode from byte, split by comma into array
+                    stdout = "".join(buffer).split(",")
+                    # Check if the simulation had been paused
+                    # (Necessary because we can't set pause to True from thread handler)
+                    if thread_events["timeout"]:
                         pause = True
                         return_code = 33
-                    except subprocess.TimeoutExpired:
-                        os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                        stdout, stderr = simulation.communicate()
-                        pause = True
-                        return_code = 33
-                # Decode from byte, split by comma into array
-                stdout = stdout.decode('utf-8').split(',')
             # Parse/return results.
 
             if return_code in [0, 33]:

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -280,25 +280,60 @@ class VariableSSACSolver(GillesPySolver):
                         raise gillespyError.ModelError("seed must be a positive integer")
 
             # begin subprocess c simulation with timeout (default timeout=0 will not timeout)
-            with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
-                try:
-                    if timeout > 0:
-                        stdout, stderr = simulation.communicate(timeout=timeout)
-                    else:
+            if os.name == "nt":
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
+                                      creationflags=subprocess.CREATE_NEW_PROCESS_GROUP) as simulation:
+                    return_code = 0
+
+                    try:
+                        # For some reason, on Windows, the KeyboardInterrupt exception breaks the pipe to stdout.
+                        # As a result, a keyboard event has to be handled gracefully without raising an exception.
+                        # Thus, a signal handler is used!
+                        def tmp_sighandler(sig, stack):
+                            simulation.send_signal(signal.CTRL_BREAK_EVENT)
+
+                        prev_sighandler = signal.signal(signal.SIGINT, tmp_sighandler)
+
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+
+                        return_code = simulation.wait()
+                    except subprocess.TimeoutExpired:
+                        simulation.send_signal(signal.CTRL_BREAK_EVENT)
                         stdout, stderr = simulation.communicate()
-                    return_code = simulation.wait()
-                except KeyboardInterrupt:
-                    os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                    stdout, stderr = simulation.communicate()
-                    pause = True
-                    return_code = 33
-                except subprocess.TimeoutExpired:
-                    os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
-                    stdout, stderr = simulation.communicate()
-                    pause = True
-                    return_code = 33
-            # Decode from byte, split by comma into array
-            stdout = stdout.decode('utf-8').split(',')
+                        pause = True
+                        return_code = 33
+                    finally:
+                        # Restore the old signal handler
+                        signal.signal(signal.SIGINT, prev_sighandler)
+                        # Decode from byte, split by comma into array
+                        stdout = stdout.decode('utf-8').split(',')
+                        # Check if the simulation had been paused
+                        # (Necessary because we can't set pause to True from signal handler)
+                        if int(stdout[-1]) != round(t):
+                            pause = True
+            else:
+                with subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True) as simulation:
+                    try:
+                        if timeout > 0:
+                            stdout, stderr = simulation.communicate(timeout=timeout)
+                        else:
+                            stdout, stderr = simulation.communicate()
+                        return_code = simulation.wait()
+                    except KeyboardInterrupt:
+                        os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
+                        stdout, stderr = simulation.communicate()
+                        pause = True
+                        return_code = 33
+                    except subprocess.TimeoutExpired:
+                        os.killpg(simulation.pid, signal.SIGINT)  # send signal to the process group
+                        stdout, stderr = simulation.communicate()
+                        pause = True
+                        return_code = 33
+                # Decode from byte, split by comma into array
+                stdout = stdout.decode('utf-8').split(',')
             # Parse/return results.
 
             if return_code in [0, 33]:

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -293,14 +293,8 @@ class VariableSSACSolver(GillesPySolver):
                         sim_buffer.append(line)
                     return ln
                 # Read output 1 block at a time, until the program is finished.
-                page_size = 0
-                while sim.poll() is None:
-                    page_size = read_next()
-                    if page_size == 0:
-                        break
-                # Keep reading from the output buffer until there's nothing left.
-                # Necessary because it's possible for there to be leftover data in the buffer.
-                while page_size > 0:
+                page_size = read_next()
+                while page_size > 0 and sim.poll() is None:
                     page_size = read_next()
 
             # Buffer to store the output of the simulation (retrieved from sim_delegate thread).

--- a/gillespy2/solvers/cpp/variable_ssa_c_solver.py
+++ b/gillespy2/solvers/cpp/variable_ssa_c_solver.py
@@ -299,32 +299,30 @@ class VariableSSACSolver(GillesPySolver):
 
             # Buffer to store the output of the simulation (retrieved from sim_delegate thread).
             buffer = []
-            # Windows event handling
             # Each platform is given their own platform-specific sub_kill() function.
-            thread_events = { "timeout": False }
+            # Windows event handling
             if os.name == "nt":
                 sub_kill = lambda sim: sim.send_signal(signal.CTRL_BREAK_EVENT)
-                simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True,
-                                              creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+                platform_args = { "creationflags": subprocess.CREATE_NEW_PROCESS_GROUP,
+                                  "start_new_session": True }
             # POSIX event handling
             else:
                 sub_kill = lambda sim: os.killpg(sim.pid, signal.SIGINT)
-                simulation = subprocess.Popen(args, stdout=subprocess.PIPE, start_new_session=True)
-            output_process = threading.Thread(name="SimulationHandlerThread",
-                                                target=sim_delegate,
-                                                args=(simulation, buffer))
+                platform_args = { "start_new_session": True }
 
-            with simulation:
-                return_code = 0
-                output_process.start()
-
+            thread_events = { "timeout": False }
+            with subprocess.Popen(args, stdout=subprocess.PIPE, **platform_args) as simulation:
                 # Put a timer on in the background, if a timeout was specified.
                 def timeout_kill():
                     thread_events["timeout"] = True
                     sub_kill(simulation)
-
+                timeout_thread = threading.Timer(timeout, timeout_kill)
                 try:
-                    timeout_thread = threading.Timer(timeout, timeout_kill)
+                    return_code = 0
+                    output_process = threading.Thread(name="SimulationHandlerThread",
+                                                    target=sim_delegate,
+                                                    args=(simulation, buffer))
+                    output_process.start()
                     if timeout > 0:
                         timeout_thread.start()
 

--- a/test/assets/test_sbml.xml
+++ b/test/assets/test_sbml.xml
@@ -1,0 +1,1088 @@
+<?xml version='1.0' encoding='UTF-8' standalone='no'?>
+<sbml xmlns="http://www.sbml.org/sbml/level2/version4" level="2" metaid="metaid_0000001" version="4">
+  <model id="model_0000001" metaid="metaid_0000002" name="Markevich2004_MAPK_phosphoRandomElementary">
+    <notes>
+      <body xmlns="http://www.w3.org/1999/xhtml">
+        <p>The model corresponds to the schema 3 of Markevich et al 2004, as described in the figure 2 and the supplementary table S2. Phosphorylations follow distributive random kinetics, while dephosphorylations follow an ordered mechanism. The phosphorylations are modeled with three elementary reactions:      <br/>
+          E+S&lt;=>ES->E+P      <br/>
+          The dephosphorylations are modeled with five elementary reactions:      <br/>
+          E+S&lt;=>ES->EP&lt;=>E+P      <br/>
+          The model reproduces figure 5 in the main article.      </p>
+            <p>The model is further described in:      <br/>
+                <strong>Signaling switches and bistability arising from multisite phosphorylation in protein kinase cascades.</strong>
+          Markevich NI, Hoek JB, Kholodenko BN. J Cell Biol. 2004 Feb 2;164(3):353-9.      <br/>
+          PMID:      <a href="http://www.ncbi.nlm.nih.gov/pubmed/14744999">14744999</a>
+          ; DOI:      <a href="http://dx.doi.org/10.1083/jcb.200308060">10.1083/jcb.200308060</a>
+                <br/>
+          Abstract:      <br/>
+          Mitogen-activated protein kinase (MAPK) cascades can operate as bistable switches residing in either of two different stable states. MAPK cascades are often embedded in positive feedback loops, which are considered to be a prerequisite for bistable behavior. Here we demonstrate that in the absence of any imposed feedback regulation, bistability and hysteresis can arise solely from a distributive kinetic mechanism of the two-site MAPK phosphorylation and dephosphorylation. Importantly, the reported kinetic properties of the kinase (MEK) and phosphatase (MKP3) of extracellular signal-regulated kinase (ERK) fulfill the essential requirements for generating a bistable switch at a single MAPK cascade level. Likewise, a cycle where multisite phosphorylations are performed by different kinases, but dephosphorylation reactions are catalyzed by the same phosphatase, can also exhibit bistability and hysteresis. Hence, bistability induced by multisite covalent modification may be a widespread mechanism of the control of protein activity.      </p>
+            <p>This model originates from BioModels Database: A Database of Annotated Published Models (http://www.ebi.ac.uk/biomodels/). It is copyright (c) 2005-2010 The BioModels.net Team.      <br/>
+          For more information see the      <a href="http://www.ebi.ac.uk/biomodels/legal.html" target="_blank">terms of use</a>
+          .      <br/>
+          To cite BioModels Database, please use:      <a href="http://www.ncbi.nlm.nih.gov/pubmed/20587024" target="_blank">Li C, Donizelli M, Rodriguez N, Dharuri H, Endler L, Chelliah V, Li L, He E, Henry A, Stefan MI, Snoep JL, Hucka M, Le Novère N, Laibe C (2010) BioModels Database: An enhanced, curated and annotated resource for published quantitative kinetic models. BMC Syst Biol., 4:92.</a>
+                </p>
+            </body>
+      
+    </notes>
+    <annotation>
+      <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:vCard="http://www.w3.org/2001/vcard-rdf/3.0#" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dcterms="http://purl.org/dc/terms/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+        <rdf:Description rdf:about="#metaid_0000002">
+	<dc:creator>
+	<rdf:Bag>
+	<rdf:li rdf:parseType="Resource">
+	<vCard:N rdf:parseType="Resource">
+	<vCard:Family>Le Novère</vCard:Family>
+	<vCard:Given>Nicolas</vCard:Given>
+	</vCard:N>
+	<vCard:EMAIL>lenov@ebi.ac.uk</vCard:EMAIL>
+	<vCard:ORG rdf:parseType="Resource">
+	<vCard:Orgname>EMBL-EBI</vCard:Orgname>
+	</vCard:ORG>
+	</rdf:li>
+	</rdf:Bag>
+	</dc:creator>
+	<dcterms:created rdf:parseType="Resource">
+	<dcterms:W3CDTF>2005-05-23T16:11:24Z</dcterms:W3CDTF>
+	</dcterms:created>
+	<dcterms:modified rdf:parseType="Resource">
+	<dcterms:W3CDTF>2012-05-15T21:42:30Z</dcterms:W3CDTF>
+	</dcterms:modified>
+	<bqmodel:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/MODEL6618552953"/>
+	</rdf:Bag>
+	</bqmodel:is>
+	<bqmodel:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/biomodels.db/BIOMD0000000028"/>
+	</rdf:Bag>
+	</bqmodel:is>
+	<bqmodel:isDescribedBy>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/pubmed/14744999"/>
+	</rdf:Bag>
+	</bqmodel:isDescribedBy>
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0000165"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	<bqbiol:hasTaxon>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/taxonomy/8355"/>
+	</rdf:Bag>
+	</bqbiol:hasTaxon>
+	</rdf:Description>
+	
+      </rdf:RDF>
+    </annotation>
+      <listOfUnitDefinitions>
+      <unitDefinition id="substance" metaid="metaid_0000003" name="nanomole (default)">
+        <listOfUnits>
+          <unit kind="mole" metaid="_035441" scale="-9"/>
+        </listOfUnits>
+      </unitDefinition>
+    </listOfUnitDefinitions>
+    <listOfCompartments>
+      <compartment id="cell" metaid="metaid_0000004" name="cell" size="1">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000004">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0005623"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </compartment>
+    </listOfCompartments>
+    <listOfSpecies>
+      <species compartment="cell" id="M" initialConcentration="800" metaid="metaid_0000005" name="ERK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000005">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MpY" initialConcentration="0" metaid="metaid_0000006" name="ERK-PY">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000006">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MpT" initialConcentration="0" metaid="metaid_0000007" name="ERK-PT">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000007">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="Mpp" initialConcentration="0" metaid="metaid_0000008" name="ERK-PP">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000008">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MEK" initialConcentration="180" metaid="metaid_0000009" name="MEK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000009">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MKP3" initialConcentration="100" metaid="metaid_0000010" name="MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000010">
+	<bqbiol:is>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q90W58"/>
+	</rdf:Bag>
+	</bqbiol:is>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MpY_MEK" initialConcentration="0" metaid="metaid_0000011" name="ERK-PY_MEK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000011">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MpT_MEK" initialConcentration="0" metaid="metaid_0000012" name="ERK-PT_MEK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000012">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="M_MEK_Y" initialConcentration="0" metaid="metaid_0000015" name="ERK_MEK_Y">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000015">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="M_MEK_T" initialConcentration="0" metaid="metaid_0000016" name="ERK_MEK_T">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000016">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q05116"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="Mpp_MKP3" initialConcentration="0" metaid="metaid_0000013" name="ERK-PP_MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000013">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q90W58"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MpY_MKP3" initialConcentration="0" metaid="metaid_0000014" name="ERK-PY_MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000014">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q90W58"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MpT_MKP3_Y" initialConcentration="0" metaid="metaid_0000017" name="ERK-PT_MKP3_Y">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000017">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q90W58"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="MpT_MKP3_T" initialConcentration="0" metaid="metaid_0000018" name="ERK-PT_MKP3_T">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000018">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q90W58"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="M_MKP3_T" initialConcentration="0" metaid="metaid_0001000" name="ERK_MKP3_T">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0001000">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q90W58"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+      <species compartment="cell" id="M_MKP3_Y" initialConcentration="0" metaid="metaid_0001001" name="ERK_MKP3_Y">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0001001">
+	<bqbiol:hasPart>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/Q90W58"/>
+	<rdf:li rdf:resource="http://identifiers.org/uniprot/P26696"/>
+	</rdf:Bag>
+	</bqbiol:hasPart>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+            </species>
+    </listOfSpecies>
+    <listOfParameters>
+      <parameter id="k1" metaid="metaid_0000019" name="k1" value="0.005"/>
+      <parameter id="k_1" metaid="metaid_0000020" name="k_1" value="1"/>
+      <parameter id="k2" metaid="metaid_0000021" name="k2" value="1.08"/>
+      <parameter id="k3" metaid="metaid_0000022" name="k3" value="0.025"/>
+      <parameter id="k_3" metaid="metaid_0000023" name="k_3" value="1"/>
+      <parameter id="k4" metaid="metaid_0000024" name="k4" value="0.007"/>
+      <parameter id="k5" metaid="metaid_0000025" name="k5" value="0.05"/>
+      <parameter id="k_5" metaid="metaid_0000026" name="k_5" value="1"/>
+      <parameter id="k6" metaid="metaid_0000027" name="k6" value="0.008"/>
+      <parameter id="k7" metaid="metaid_0000028" name="k7" value="0.005"/>
+      <parameter id="k_7" metaid="metaid_0000029" name="k_7" value="1"/>
+      <parameter id="k8" metaid="metaid_0000030" name="k8" value="0.45"/>
+      <parameter id="h1" metaid="metaid_0000031" name="h1" value="0.045"/>
+      <parameter id="h_1" metaid="metaid_0000032" name="h_1" value="1"/>
+      <parameter id="h2" metaid="metaid_0000033" name="h2" value="0.092"/>
+      <parameter id="h3" metaid="metaid_0000034" name="h3" value="1"/>
+      <parameter id="h_3" metaid="metaid_0000035" name="h_3" value="0.01"/>
+      <parameter id="h4" metaid="metaid_0000036" name="h4" value="0.01"/>
+      <parameter id="h_4" metaid="metaid_0000037" name="h_4" value="1"/>
+      <parameter id="h5" metaid="metaid_0000038" name="h5" value="0.5"/>
+      <parameter id="h6" metaid="metaid_0000039" name="h6" value="0.086"/>
+      <parameter id="h_6" metaid="metaid_0000040" name="h_6" value="0.0011"/>
+      <parameter id="h7" metaid="metaid_0000041" name="h7" value="0.01"/>
+      <parameter id="h_7" metaid="metaid_0000042" name="h_7" value="1"/>
+      <parameter id="h8" metaid="metaid_0000043" name="h8" value="0.47"/>
+      <parameter id="h9" metaid="metaid_0000044" name="h9" value="0.14"/>
+      <parameter id="h_9" metaid="metaid_0000045" name="h_9" value="0.0018"/>
+    </listOfParameters>
+    <listOfReactions>
+      <reaction id="reaction_0000001" metaid="metaid_0000046" name="binding ERK and MEK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000046">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_495"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1780"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0051019"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0031434"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035453" species="M"/>
+          <speciesReference metaid="_035465" species="MEK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035477" species="M_MEK_Y"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035489">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k1 </ci>
+                  <ci> M </ci>
+                  <ci> MEK </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k_1 </ci>
+                  <ci> M_MEK_Y </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000002" metaid="metaid_0000047" name="tyr phosphorylation of ERK" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000047">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_2247"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_136"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.12.2"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0018108"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0004708"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035501" species="M_MEK_Y"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035513" species="MpY"/>
+          <speciesReference metaid="_035525" species="MEK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035537">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <ci> k2 </ci>
+              <ci> M_MEK_Y </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000003" metaid="metaid_0000048" name="binding ERK-PY and MEK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000048">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_495"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1780"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0051019"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0031434"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035550" species="MpY"/>
+          <speciesReference metaid="_035562" species="MEK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035574" species="MpY_MEK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035587">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k3 </ci>
+                  <ci> MpY </ci>
+                  <ci> MEK </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k_3 </ci>
+                  <ci> MpY_MEK </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000004" metaid="metaid_0000049" name="thr phosphorylation of ERK" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000049">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_2247"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_136"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.12.2"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0004708"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0018107"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0000187"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035599" species="MpY_MEK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035611" species="Mpp"/>
+          <speciesReference metaid="_035623" species="MEK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035635">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <ci> k4 </ci>
+              <ci> MpY_MEK </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000005" metaid="metaid_0000050" name="binding ERK and MEK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000050">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_495"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1780"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0051019"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0031434"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035647" species="M"/>
+          <speciesReference metaid="_035659" species="MEK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035671" species="M_MEK_T"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035683">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k5 </ci>
+                  <ci> M </ci>
+                  <ci> MEK </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k_5 </ci>
+                  <ci> M_MEK_T </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000006" metaid="metaid_0000051" name="thr phosphorylation of ERK" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000051">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_2247"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_136"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.12.2"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0018107"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0004708"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035695" species="M_MEK_T"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035707" species="MpT"/>
+          <speciesReference metaid="_035719" species="MEK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035731">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <ci> k6 </ci>
+              <ci> M_MEK_T </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000007" metaid="metaid_0000052" name="binding ERK-PT and MEK">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000052">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_1780"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_495"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0051019"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0031434"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035743" species="MpT"/>
+          <speciesReference metaid="_035755" species="MEK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035767" species="MpT_MEK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035779">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> k7 </ci>
+                  <ci> MpT </ci>
+                  <ci> MEK </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> k_7 </ci>
+                  <ci> MpT_MEK </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000008" metaid="metaid_0000053" name="tyr phosphorylation of ERK" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000053">
+              <bqbiol:isHomologTo>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_2247"/>
+	<rdf:li rdf:resource="http://identifiers.org/reactome/REACT_136"/>
+	</rdf:Bag>
+	</bqbiol:isHomologTo>
+	
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/2.7.12.2"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0000187"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0018108"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0004708"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035791" species="MpT_MEK"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035803" species="Mpp"/>
+          <speciesReference metaid="_035815" species="MEK"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035827">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <ci> k8 </ci>
+              <ci> MpT_MEK </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000009" metaid="metaid_0000054" name="binding ERK-PP and MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000054">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0051019"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035839" species="Mpp"/>
+          <speciesReference metaid="_035851" species="MKP3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035863" species="Mpp_MKP3"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035875">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> h1 </ci>
+                  <ci> Mpp </ci>
+                  <ci> MKP3 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> h_1 </ci>
+                  <ci> Mpp_MKP3 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000010" metaid="metaid_0000055" name="dephosphorylation of tyr on ERK-PP" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000055">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0006470"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0000188"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035887" species="Mpp_MKP3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035899" species="MpT_MKP3_Y"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035911">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <ci> h2 </ci>
+              <ci> Mpp_MKP3 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000011" metaid="metaid_0000056" name="dissociation ERK-PT and MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000056">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0043241"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035923" species="MpT_MKP3_Y"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035935" species="MpT"/>
+          <speciesReference metaid="_035947" species="MKP3"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035959">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> h3 </ci>
+                  <ci> MpT_MKP3_Y </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> h_3 </ci>
+                  <ci> MpT </ci>
+                  <ci> MKP3 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000012" metaid="metaid_0000057" name="dephosphorylation of ERK-PT" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000057">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0006470"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_035971" species="MpT_MKP3_T"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_035983" species="M_MKP3_T"/>
+        </listOfProducts>
+        <kineticLaw metaid="_035995">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <ci> h5 </ci>
+              <ci> MpT_MKP3_T </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000013" metaid="metaid_0000058" name="binding ERK-PT and MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000058">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0051019"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_036007" species="MpT"/>
+          <speciesReference metaid="_036019" species="MKP3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_036031" species="MpT_MKP3_T"/>
+        </listOfProducts>
+        <kineticLaw metaid="_036043">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> h4 </ci>
+                  <ci> MpT </ci>
+                  <ci> MKP3 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> h_4 </ci>
+                  <ci> MpT_MKP3_T </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000014" metaid="metaid_0000059" name="dephosphorylation of ERK-PY" reversible="false">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000059">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/ec-code/3.1.3.16"/>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0006470"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_036055" species="MpY_MKP3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_036067" species="M_MKP3_Y"/>
+        </listOfProducts>
+        <kineticLaw metaid="_036079">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <ci> h8 </ci>
+              <ci> MpY_MKP3 </ci>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000015" metaid="metaid_0000060" name="dissociation ERK and MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000060">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0043241"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_036092" species="M_MKP3_T"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_036104" species="M"/>
+          <speciesReference metaid="_036116" species="MKP3"/>
+        </listOfProducts>
+        <kineticLaw metaid="_036128">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> h6 </ci>
+                  <ci> M_MKP3_T </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> h_6 </ci>
+                  <ci> M </ci>
+                  <ci> MKP3 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000017" metaid="metaid_0000061" name="binding ERK-PY and MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000061">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0051019"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_036140" species="MpY"/>
+          <speciesReference metaid="_036152" species="MKP3"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_036164" species="MpY_MKP3"/>
+        </listOfProducts>
+        <kineticLaw metaid="_036177">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> h7 </ci>
+                  <ci> MpY </ci>
+                  <ci> MKP3 </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> h_7 </ci>
+                  <ci> MpY_MKP3 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+      <reaction id="reaction_0000019" metaid="metaid_0000063" name="Dissociation ERK and MKP3">
+        <annotation>
+          <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:bqmodel="http://biomodels.net/model-qualifiers/" xmlns:bqbiol="http://biomodels.net/biology-qualifiers/">
+            <rdf:Description rdf:about="#metaid_0000063">
+	<bqbiol:isVersionOf>
+	<rdf:Bag>
+	<rdf:li rdf:resource="http://identifiers.org/obo.go/GO:0043241"/>
+	</rdf:Bag>
+	</bqbiol:isVersionOf>
+	</rdf:Description>
+	
+          </rdf:RDF>
+        </annotation>
+              <listOfReactants>
+          <speciesReference metaid="_036189" species="M_MKP3_Y"/>
+        </listOfReactants>
+        <listOfProducts>
+          <speciesReference metaid="_036201" species="M"/>
+          <speciesReference metaid="_036213" species="MKP3"/>
+        </listOfProducts>
+        <kineticLaw metaid="_036225">
+          <math xmlns="http://www.w3.org/1998/Math/MathML">          
+            <apply>
+              <times/>
+              <ci> cell </ci>
+              <apply>
+                <minus/>
+                <apply>
+                  <times/>
+                  <ci> h9 </ci>
+                  <ci> M_MKP3_Y </ci>
+                </apply>
+                <apply>
+                  <times/>
+                  <ci> h_9 </ci>
+                  <ci> M </ci>
+                  <ci> MKP3 </ci>
+                </apply>
+              </apply>
+            </apply>
+          </math>
+                </kineticLaw>
+      </reaction>
+    </listOfReactions>
+  </model>
+</sbml>

--- a/test/test_SBML.py
+++ b/test/test_SBML.py
@@ -1,6 +1,7 @@
 import unittest
 import tempfile
 import os
+import ssl
 from example_models import Example
 from gillespy2.core.model import import_SBML, export_SBML
 from gillespy2 import ODESolver
@@ -15,13 +16,21 @@ class TestSBML(unittest.TestCase):
             return
 
         try:
-            from urllib2 import urlopen
+            from urllib2 import urlopen, URLError
 
         except ImportError:
             from urllib.request import urlopen
+            from urllib.error import URLError
 
         sbml_file = 'https://www.ebi.ac.uk/biomodels/model/download/BIOMD0000000028.2?filename=BIOMD0000000028_url.xml'
-        response = urlopen(sbml_file)
+        try:
+            response = urlopen(sbml_file)
+        except URLError:
+            from certifi import where
+            ctx = ssl.create_default_context()
+            ctx.load_default_certs()
+            ctx.load_verify_locations(where())
+            response = urlopen(sbml_file, context=ctx)
         tmp = tempfile.NamedTemporaryFile(delete=False)
         tmp.write(response.read())
         tmp.close()

--- a/test/test_SBML.py
+++ b/test/test_SBML.py
@@ -1,7 +1,5 @@
 import unittest
 import tempfile
-import os
-import ssl
 from example_models import Example
 from gillespy2.core.model import import_SBML, export_SBML
 from gillespy2 import ODESolver
@@ -15,27 +13,7 @@ class TestSBML(unittest.TestCase):
         except ImportError:
             return
 
-        try:
-            from urllib2 import urlopen, URLError
-
-        except ImportError:
-            from urllib.request import urlopen
-            from urllib.error import URLError
-
-        sbml_file = 'https://www.ebi.ac.uk/biomodels/model/download/BIOMD0000000028.2?filename=BIOMD0000000028_url.xml'
-        try:
-            response = urlopen(sbml_file)
-        except URLError:
-            from certifi import where
-            ctx = ssl.create_default_context()
-            ctx.load_default_certs()
-            ctx.load_verify_locations(where())
-            response = urlopen(sbml_file, context=ctx)
-        tmp = tempfile.NamedTemporaryFile(delete=False)
-        tmp.write(response.read())
-        tmp.close()
-        sbml_model, errors = import_SBML(tmp.name)
-        os.remove(tmp.name)
+        sbml_model, errors = import_SBML("assets/test_sbml.xml")
         sbml_results = sbml_model.run(solver=ODESolver)
 
     def test_sbml_export_conversion(self):

--- a/test/test_SBML.py
+++ b/test/test_SBML.py
@@ -1,5 +1,6 @@
 import unittest
 import tempfile
+import os
 from example_models import Example
 from gillespy2.core.model import import_SBML, export_SBML
 from gillespy2 import ODESolver
@@ -13,7 +14,8 @@ class TestSBML(unittest.TestCase):
         except ImportError:
             return
 
-        sbml_model, errors = import_SBML("assets/test_sbml.xml")
+        model_path = os.path.join(os.path.dirname(__file__), "assets", "test_sbml.xml")
+        sbml_model, errors = import_SBML(model_path)
         sbml_results = sbml_model.run(solver=ODESolver)
 
     def test_sbml_export_conversion(self):

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -65,11 +65,13 @@ class TestPauseResume(unittest.TestCase):
                 [py_path, model_path, 'TauLeapingSolver'],
                 [py_path, model_path, 'ODESolver']]
         for arg in args:
-            p = subprocess.Popen(arg, start_new_session=True, stdout=subprocess.PIPE)
-            time.sleep(2)
             if os.name == 'nt':
-                p.send_signal(signal.CTRL_C_EVENT)
+                p = subprocess.Popen(arg, stdout=subprocess.PIPE, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
+                time.sleep(2)
+                p.send_signal(signal.CTRL_BREAK_EVENT)
             else:
+                p = subprocess.Popen(arg, start_new_session=True, stdout=subprocess.PIPE)
+                time.sleep(2)
                 os.kill(p.pid, signal.SIGINT)
             out, err = p.communicate()
             # End time for Oregonator is 5. If indexing into a numpy array using the form:

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -58,14 +58,17 @@ class TestPauseResume(unittest.TestCase):
 
     def test_pause(self):
         py_path = which('python3')
-        model_path = os.path.join(os.getcwd(), 'pause_model.py')
+        model_path = os.path.join(os.path.dirname(__file__), 'pause_model.py')
         args = [[py_path, model_path, 'NumPySSASolver'],
                 [py_path, model_path, 'TauLeapingSolver'],
                 [py_path, model_path, 'ODESolver']]
         for arg in args:
             p = subprocess.Popen(arg, start_new_session=True, stdout=subprocess.PIPE)
             time.sleep(2)
-            os.kill(p.pid, signal.SIGINT)
+            if os.name == 'nt':
+                p.send_signal(signal.CTRL_C_EVENT)
+            else:
+                os.kill(p.pid, signal.SIGINT)
             out, err = p.communicate()
             # End time for Oregonator is 5. If indexing into a numpy array using the form:
             # results[0][-1][0] (where .run(show_labels=False), this index being the last time in the index

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -1,6 +1,7 @@
 import unittest
 import numpy as np
 import subprocess
+from shutil import which
 from example_models import MichaelisMenten, Oregonator
 from gillespy2.core.results import Results, Trajectory
 from gillespy2.core import Species
@@ -56,8 +57,11 @@ class TestPauseResume(unittest.TestCase):
                                                  t=1)
 
     def test_pause(self):
-        args = [['python3', 'pause_model.py', 'NumPySSASolver'], ['python3', 'pause_model.py', 'TauLeapingSolver'],
-                ['python3', 'pause_model.py', 'ODESolver']]
+        py_path = which('python3')
+        model_path = os.path.join(os.getcwd(), 'pause_model.py')
+        args = [[py_path, model_path, 'NumPySSASolver'],
+                [py_path, model_path, 'TauLeapingSolver'],
+                [py_path, model_path, 'ODESolver']]
         for arg in args:
             p = subprocess.Popen(arg, start_new_session=True, stdout=subprocess.PIPE)
             time.sleep(2)

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -58,6 +58,8 @@ class TestPauseResume(unittest.TestCase):
 
     def test_pause(self):
         py_path = which('python3')
+        if py_path is None:
+            py_path = which('python')
         model_path = os.path.join(os.path.dirname(__file__), 'pause_model.py')
         args = [[py_path, model_path, 'NumPySSASolver'],
                 [py_path, model_path, 'TauLeapingSolver'],


### PR DESCRIPTION
Resolve failing tests on Windows platforms.

- On ~~Windows~~ all platforms, `.communicate()` call is replaced with manual buffer reads
- Use Win32 equivalent of `signal()` in C solvers
- Buffer reads performed on background thread
- Updates made to both `SSACSolver` and `VariableSSACSolver` classes

Unrelated fixes:
- ~~Resolve weird TLS certificate bug on SBML tests for Windows tests in Travis~~
- Replace HTTP fetch of example SBML file with local copy

Closes #480, Closes #426