### PR TITLE
Fix identical trajectories for `Results.to_array()`

### DIFF
--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -210,9 +210,9 @@ class Results(UserList):
         results = []
         size1 = len(self.data[0]['time'])
         size2 = len(self.data[0])
-        newArray = np.zeros((size1, size2))
 
         for trajectory in range(0,len(self.data)):
+            newArray = np.zeros((size1, size2))
             for i, key in enumerate(self.data[trajectory]):
                 newArray[:, i] = self.data[trajectory][key]
             results.append(newArray)


### PR DESCRIPTION
Calling `Results.to_array()` with multiple trajectories resulted in `num_trajectories` copies of the same NumPy array. The issue was caused by only one NumPy being initialized at the beginning of the function call. This NumPy array was being reused for each trajectory.

The solution is to initialize a new array for each trajectory, rather than initializing one only at the beginning of the function.

- Changes made to the `Results.to_array()` method

Closes #485 