### PR TITLE
HOTFIX: Fixed StochMLDocument.to_model() AttributeError.

### DIFF
--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -1181,7 +1181,7 @@ class StochMLDocument():
                         reaction.marate = model.listOfParameters[
                             generated_rate_name]
 
-                    reaction.__create_mass_action()
+                    reaction.create_mass_action()
                 except Exception as e:
                     raise
             elif type == 'customized':

--- a/gillespy2/core/reaction.py
+++ b/gillespy2/core/reaction.py
@@ -91,7 +91,7 @@ class Reaction(SortableObject):
                 self.marate = None
             else:
                 self.marate = rate
-                self.__create_mass_action()
+                self.create_mass_action()
         else:
             self.type = "customized"
 
@@ -230,7 +230,7 @@ class Reaction(SortableObject):
         if len(self.reactants) == 0 and len(self.products) == 0:
             raise ReactionError("You must have a non-zero number of reactants or products.")
 
-    def __create_mass_action(self):
+    def create_mass_action(self):
         """
         Initializes the mass action propensity function given
         self.reactants and a single parameter value.


### PR DESCRIPTION
Error was caused by `to_model()` using the private function `reaction.__create_mass_action()`.

Closes #512 