### PR TITLE
Update workflow payload to include `ref` field

### DIFF
--- a/.github/workflows/biosim-release.yml
+++ b/.github/workflows/biosim-release.yml
@@ -10,6 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DOWNSTREAM_REPOSITORY: biosimulators/Biosimulators_GillesPy2
+      DOWNSTREAM_REF: refs/heads/dev
       GH_ISSUE_USERNAME: ${{ secrets.GH_ISSUE_USERNAME }}
       GH_ISSUE_TOKEN: ${{ secrets.GH_ISSUE_TOKEN }}
     steps:
@@ -22,5 +23,4 @@ jobs:
             -u "${GH_ISSUE_USERNAME}:${GH_ISSUE_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
                https://api.github.com/repos/${DOWNSTREAM_REPOSITORY}/actions/workflows/${WORKFLOW_FILE}/dispatches \
-            -d "{\"inputs\": {\"simulatorVersion\": \"${PACKAGE_VERSION}\", \"simulatorVersionLatest\": \"true\"}}"
-
+            -d "{\"inputs\": {\"simulatorVersion\": \"${PACKAGE_VERSION}\", \"simulatorVersionLatest\": \"true\"}, \"ref\": \"${DOWNSTREAM_REF}\"}"


### PR DESCRIPTION
Includes a minor fix to address a validation issue preventing dispatch. Tested on the command line with a valid token, should allow for automatic rebuilds once merged into `main` on release.

As mentioned in #519 the token provided by Dr. Drawert now has the proper permissions to invoke a workflow dispatch once merged.

- `ref` points to the branch's ref to point to in target repo
- Set to their `dev` branch by default
- Required property for the `workflow_dispatch` action

Closes #519