### PR TITLE
Fix: precompile regression

### DIFF
--- a/gillespy2/solvers/cpp/build/build_engine.py
+++ b/gillespy2/solvers/cpp/build/build_engine.py
@@ -130,6 +130,18 @@ class BuildEngine():
         self.make.build_simulation(simulation_name, template_dir=str(self.template_dir))
         return str(self.make.output_file)
 
+    def get_executable_path(self) -> str:
+        """
+        Resolves the filepath of the simulation executable.
+        Only valid after the simulation has been built.
+
+        :return: String containing path to executable.
+        None if no executable exists.
+        """
+        if not os.path.exists(self.make.output_file):
+            return None
+        return str(self.make.output_file)
+
     def clean(self):
         """
         Delete the output directory and all other associated build artifacts.

--- a/gillespy2/solvers/cpp/c_solver.py
+++ b/gillespy2/solvers/cpp/c_solver.py
@@ -43,6 +43,7 @@ class CSolver:
         if self.model is None:
             return
 
+        self._build(model, self.target, variable, False)
         self.species_mappings = self.model.sanitized_species_names()
         self.species = list(self.species_mappings.keys())
         self.parameter_mappings = self.model.sanitized_parameter_names()
@@ -74,11 +75,14 @@ class CSolver:
         """
 
         # Prepare the build workspace.
-        self.build_engine = BuildEngine(debug=debug, output_dir=self.output_directory)
-        self.build_engine.prepare(model, variable)
+        if self.build_engine is None or self.build_engine.get_executable_path() is None:
+            self.build_engine = BuildEngine(debug=debug, output_dir=self.output_directory)
+            self.build_engine.prepare(model, variable)
+            # Compile the simulation, returning the path of the executable.
+            return self.build_engine.build_simulation(simulation_name)
 
-        # Compile the simulation, returning the path of the executable.
-        return self.build_engine.build_simulation(simulation_name)
+        # Assume that the simulation has already been built.
+        return self.build_engine.get_executable_path()
 
     def _run_async(self, sim_exec: str, sim_args: "list[str]", decoder: SimDecoder, timeout: int = 0):
         """

--- a/test/test_c_solvers.py
+++ b/test/test_c_solvers.py
@@ -15,6 +15,11 @@ class TestCSolvers(unittest.TestCase):
     """
 
     test_model = example_models.Dimerization()
+    base_solvers = [
+        SSACSolver,
+        ODECSolver,
+        TauLeapingCSolver,
+    ]
     solvers = {
         SSACSolver.target: SSACSolver(model=test_model),
         ODECSolver.target: ODECSolver(model=test_model),
@@ -86,3 +91,17 @@ class TestCSolvers(unittest.TestCase):
                 solver.build_engine.clean()
                 self.assertFalse(os.path.exists(exe),
                                  "Simulation output not cleaned up after call to .clean().")
+
+    def test_solver_precompile(self):
+        """
+        Ensure that a pre-built C++ solver actually builds the simulation before running.
+        """
+        for solver in self.base_solvers:
+            with self.subTest(solver=solver.name):
+                base_solver = solver(model=self.test_model)
+                self.assertIsNotNone(base_solver.build_engine, 
+                                     "Build engine not created at solver's construction")
+                self.assertIsNotNone(base_solver.build_engine.get_executable_path(),
+                                     "Build engine has no associated executable")
+                self.assertTrue(os.access(base_solver.build_engine.get_executable_path(), os.X_OK),
+                                "Solver executable invalid or missing at solver's construction")


### PR DESCRIPTION
With the build refactor, pre-constructing a solver did not allow one to re-use a solver, causing successive calls with the same solver instance to rebuild.

The fix was to modify the `build()` call to be memoized, and add a call to `build()` into the constructor when a model is provided.