### PR TITLE
Fix `Model#get_best_solver_algo`

### DIFF
--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -861,8 +861,9 @@ class Model(SortableObject, Jsonify):
         """
         If user has specified a particular algorithm, we return either the Python or C++ version of that algorithm
         """
-        from gillespy2.solvers.cpp import can_use_cpp
         from gillespy2.solvers.numpy import can_use_numpy
+        from gillespy2.solvers.cpp.build.build_engine import BuildEngine
+        can_use_cpp = not len(BuildEngine.get_missing_dependencies())
 
         if not can_use_cpp and can_use_numpy:
             raise ModelError("Please install C++ or Numpy to use GillesPy2 solvers.")


### PR DESCRIPTION
Reference to `can_use_cpp` on import causes `get_best_solver_algo` to fail
- Replace deprecated reference to `can_use_cpp` with import of `BuildEngine`
- Call to `BuildEngine#get_missing_dependencies`

Closes #547