### PR TITLE
Fix ODE C++ solvers for higher-order reactions

### DIFF
--- a/gillespy2/core/reaction.py
+++ b/gillespy2/core/reaction.py
@@ -328,12 +328,12 @@ class Reaction(SortableObject, Jsonify):
         """
         self.annotation = annotation
 
-    def sanitized_propensity_function(self, species_mappings, parameter_mappings):
+    def sanitized_propensity_function(self, species_mappings, parameter_mappings, ode=False):
         names = sorted(list(species_mappings.keys()) + list(parameter_mappings.keys()), key=lambda x: len(x),
                        reverse=True)
         replacements = [parameter_mappings[name] if name in parameter_mappings else species_mappings[name]
                         for name in names]
-        sanitized_propensity = self.propensity_function
+        sanitized_propensity = self.ode_propensity_function if ode else self.propensity_function
         for id, name in enumerate(names):
             sanitized_propensity = sanitized_propensity.replace(name, "{" + str(id) + "}")
         return sanitized_propensity.format(*replacements)

--- a/gillespy2/solvers/cpp/build/template_gen.py
+++ b/gillespy2/solvers/cpp/build/template_gen.py
@@ -77,13 +77,24 @@ def get_model_defines(model: Model, variable=False) -> "dict[str, str]":
     
     # Get definitions for propensities
     stoch_propensities = []
+    ode_propensities = []
     for rxn in reactions:
+        # ODE and non-ODE propensities can sometimes differ.
+        # As a result, each one needs to be sanitized and evaluated separately.
         stoch_propensity = rxn.sanitized_propensity_function(
             model.sanitized_species_names(),
-            model.sanitized_parameter_names())
+            model.sanitized_parameter_names(),
+            ode=False)
+        ode_propensity = rxn.sanitized_propensity_function(
+            model.sanitized_species_names(),
+            model.sanitized_parameter_names(),
+            ode=True)
         stoch_propensities.append(stoch_propensity)
-    stoch_propensity_definitions = template_def_propensities(stoch_propensities)
+        ode_propensities.append(ode_propensity)
+    stoch_propensity_definitions = template_def_propensities(stoch_propensities, ode=False)
+    ode_propensity_definitions = template_def_propensities(ode_propensities, ode=True)
     results.update(stoch_propensity_definitions)
+    results.update(ode_propensity_definitions)
 
     return results
 


### PR DESCRIPTION
Fixes an issue where higher-order reactions use the wrong propensity function.

- New flag in `Reaction#sanitized_propensity_function`: `ode`
  - Boolean which indicates that `ode_propensity_function` should be used
- Update `get_model_defines` to populate both ODE and non-ODE propensities

Closes #548