### PR TITLE
Updated legacy readthedocs.io links to new documentation domain.

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ With a few additional Python matplotlib commands to create figure labels and suc
 Getting help
 ------------
 
-GillesPy2's [online documentation](https://gillespy2.readthedocs.io/en/latest/) provides more details about using the software.  If you find any problem with GillesPy2 or the documentation, please report it using the [GitHub issue tracker](https://github.com/StochSS/GillesPy2/issues) for this repository.  You can also contact Dr. [Brian Drawert](http://www.cs.unca.edu/~drawert) directly with questions and suggestions.
+GillesPy2's [online documentation](https://stochss.github.io/GillesPy2) provides more details about using the software.  If you find any problem with GillesPy2 or the documentation, please report it using the [GitHub issue tracker](https://github.com/StochSS/GillesPy2/issues) for this repository.  You can also contact Dr. [Brian Drawert](http://www.cs.unca.edu/~drawert) directly with questions and suggestions.
 
 Contributing
 ------------

--- a/examples/StartHere.ipynb
+++ b/examples/StartHere.ipynb
@@ -231,7 +231,7 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### You can find a more thorough list of `model.run()` arguments in [the documentation](https://gillespy2.readthedocs.io/en/latest/classes/gillespy2.core.html#gillespy2.core.gillespy2.Model.run) to customize the behavior of your simulations."
+    "### You can find a more thorough list of `model.run()` arguments in [the documentation](https://stochss.github.io/GillesPy2/classes/gillespy2.core.html#gillespy2.core.model.Model.run) to customize the behavior of your simulations."
    ],
    "metadata": {}
   },
@@ -306,14 +306,14 @@
   {
    "cell_type": "markdown",
    "source": [
-    "### A more complete list of `results.plot()` arguments can be found [in the documentation](https://gillespy2.readthedocs.io/en/latest/classes/gillespy2.core.html#gillespy2.core.results.EnsembleResults.plot)."
+    "### A more complete list of `results.plot()` arguments can be found [in the documentation](https://stochss.github.io/GillesPy2/classes/gillespy2.core.html#gillespy2.core.results.Results.plot)."
    ],
    "metadata": {}
   },
   {
    "cell_type": "markdown",
    "source": [
-    "### GillesPy2 also offers built-in plotly and statistical data plotting. You can view these functions in the [`Results` module documentation](https://gillespy2.readthedocs.io/en/latest/classes/gillespy2.core.html#module-gillespy2.core.results)."
+    "### GillesPy2 also offers built-in plotly and statistical data plotting. You can view these functions in the [`Results` module documentation](https://stochss.github.io/GillesPy2/classes/gillespy2.core.html#module-gillespy2.core.results)."
    ],
    "metadata": {}
   },


### PR DESCRIPTION
Closes #566 