### PR TITLE
Fix type narrowing errors for C++ solvers

### DIFF
--- a/gillespy2/solvers/cpp/c_base/model.cpp
+++ b/gillespy2/solvers/cpp/c_base/model.cpp
@@ -19,19 +19,21 @@
 #include "model.h"
 
 namespace Gillespy {
-	Model::Model(
+
+	template <typename PType>
+	Model<PType>::Model(
 		std::vector<std::string> species_names,
-		std::vector<unsigned int> species_populations,
+		std::vector<double> species_populations,
 		std::vector<std::string> reaction_names) :
 		number_species(species_names.size()),
 		number_reactions(reaction_names.size()) {
 
-		species = std::make_unique<Species[]>(number_species);
+		species = std::make_unique<Species<PType>[]>(number_species);
 		reactions = std::make_unique<Reaction[]>(number_reactions);
 
 		for (unsigned int i = 0; i < number_species; i++) {
 			species[i].id = i;
-			species[i].initial_population = species_populations[i];
+			species[i].initial_population = static_cast<PType>(species_populations[i]);
 			species[i].name = species_names[i];
 		}
 
@@ -47,7 +49,8 @@ namespace Gillespy {
 		}
 	}
 
-	void Model::update_affected_reactions() {
+	template <typename PType>
+	void Model<PType>::update_affected_reactions() {
 		// Clear affected_reactions for each reaction.
 		for (unsigned int i = 0; i < number_reactions; i++) {
 			reactions[i].affected_reactions.clear();
@@ -66,7 +69,7 @@ namespace Gillespy {
 	}
 
 	template <typename TNum>
-	void init_timeline(Model *model, Simulation<TNum> &simulation) {
+	void init_timeline(Model<TNum> *model, Simulation<TNum> &simulation) {
 		double timestep_size = simulation.end_time / (simulation.number_timesteps - 1);
 		simulation.timeline = new double[simulation.number_timesteps];
 
@@ -76,7 +79,7 @@ namespace Gillespy {
 	}
 
 	template <typename TNum>
-	void init_simulation(Model *model, Simulation<TNum> &simulation) {
+	void init_simulation(Model<TNum> *model, Simulation<TNum> &simulation) {
 		init_timeline(model, simulation);
 
 		unsigned int trajectory_size = simulation.number_timesteps * (model->number_species);
@@ -138,9 +141,16 @@ namespace Gillespy {
 		os << (int)current_time;
 	}
 
+	// DETERMINISTIC SIMULATIONS: explicit instantation of real-valued data structures.
+	template struct Species<double>;
+	template struct Model<double>;
 	template struct Simulation<double>;
+
+	// STOCHASTIC SIMULATIONS: explicit instantiation of discrete-valued data structures.
+	template struct Species<unsigned int>;
+	template struct Model<unsigned int>;
 	template struct Simulation<unsigned int>;
 
-	template void init_simulation<double>(Model *model, Simulation<double> &simulation);
-	template void init_simulation<unsigned int>(Model *model, Simulation<unsigned int> &simulation);
+	template void init_simulation<double>(Model<double> *model, Simulation<double> &simulation);
+	template void init_simulation<unsigned int>(Model<unsigned int> *model, Simulation<unsigned int> &simulation);
 }

--- a/gillespy2/solvers/cpp/c_base/model.h
+++ b/gillespy2/solvers/cpp/c_base/model.h
@@ -25,9 +25,11 @@
 #include <iostream>
 
 namespace Gillespy {
+
+	template <typename PType>
 	struct Species {
 		unsigned int id;
-		unsigned int initial_population;
+		PType initial_population;
 
 		std::string name;
 
@@ -48,18 +50,19 @@ namespace Gillespy {
 		std::unique_ptr<int[]> species_change;
 	};
 
+	template <typename PType>
 	struct Model {
 		unsigned int number_species;
 		unsigned int number_reactions;
 
-		std::unique_ptr<Species[]> species;
+		std::unique_ptr<Species<PType>[]> species;
 		std::unique_ptr<Reaction[]> reactions;
 
 		void update_affected_reactions();
 
 		Model(
 			std::vector<std::string> species_names,
-			std::vector<unsigned int> species_populations,
+			std::vector<double> species_populations,
 			std::vector<std::string> reaction_names
 		);
 	};
@@ -88,7 +91,7 @@ namespace Gillespy {
 		PType *trajectories_1D;
 		PType ***trajectories;
 
-		Model *model;
+		Model<PType> *model;
 
 		IPropensityFunction *propensity_function;
 
@@ -99,11 +102,29 @@ namespace Gillespy {
 	};
 
 	template <typename TNum>
-	void init_simulation(Model *model, Simulation<TNum> &simulation);
+	void init_simulation(Model<TNum> *model, Simulation<TNum> &simulation);
 
+	/* ================================= *
+	 * === DETERMINISTIC SIMULATIONS === *
+	 * ================================= */
+
+	// Deterministic Species: species whose initial and runtime values are continuous.
+	extern template struct Species<double>;
+	// Deterministic Model: species state represented using concentration values.
+	extern template struct Model<double>;
+	// Deterministic Simulation: run using a continuous-valued model.
 	extern template struct Simulation<double>;
-	extern template void init_simulation<double>(Model *model, Simulation<double> &simulation);
+	extern template void init_simulation<double>(Model<double> *model, Simulation<double> &simulation);
 
+	/* ============================== *
+	 * === STOCHASTIC SIMULATIONS === *
+	 * ============================== */
+
+	// Stochastic Species: species whose initial and runtime values are discrete.
+	extern template struct Species<unsigned int>;
+	// Stochastic Model: species state represented using discrete population values.
+	extern template struct Model<unsigned int>;
+	// Stochastic Simulation: run using a discrete-valued model.
 	extern template struct Simulation<unsigned int>;
-	extern template void init_simulation<unsigned int>(Model *model, Simulation<unsigned int> &simulation);
+	extern template void init_simulation<unsigned int>(Model<unsigned int> *model, Simulation<unsigned int> &simulation);
 }

--- a/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESimulation.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[]) {
 	number_timesteps = parser.timesteps;
 	increment = parser.increment;
 
-	Model model(species_names, species_populations, reaction_names);
+	Model<double> model(species_names, species_populations, reaction_names);
 	add_reactions(model);
 
 	if (seed_time)

--- a/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.cpp
@@ -60,7 +60,7 @@ namespace Gillespy
 		sunindextype N = (simulation->model)->number_species;
 		N_Vector y0 = N_VNew_Serial(N);
 
-		Model *simulation_model = simulation->model;
+		Model<double> *simulation_model = simulation->model;
 
 		// Add species initial conditions to the current state vectory `y0`.
 		for (unsigned int species_index = 0; species_index < simulation_model->number_species; species_index++)
@@ -138,7 +138,7 @@ namespace Gillespy
 	{
 		UserData *sim_data = (UserData *)user_data;
 		Simulation<double> *simulation = sim_data->my_sim;
-		Model *model = simulation->model;
+		Model<double> *model = simulation->model;
 
 		// N_VGetArrayPointer returns a pointer to the data property within N_Vector.
 		realtype *ydata = N_VGetArrayPointer(y);

--- a/gillespy2/solvers/cpp/c_base/ssa_cpp_solver/SSASimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/ssa_cpp_solver/SSASimulation.cpp
@@ -72,7 +72,7 @@ int main(int argc, char *argv[])
 	number_trajectories = parser.trajectories;
 	number_timesteps = parser.timesteps;
 	
-	Model model(species_names, species_populations, reaction_names);
+	Model<unsigned int> model(species_names, species_populations, reaction_names);
 	add_reactions(model);
 	
 	if (seed_time)    

--- a/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSimulation.cpp
@@ -73,7 +73,7 @@ int main(int argc, char* argv[]){
 	number_timesteps = parser.timesteps;
 	tau_tol = parser.tau_tol;
 
-	Model model(species_names, species_populations, reaction_names);
+	Model<unsigned int> model(species_names, species_populations, reaction_names);
 	add_reactions(model);
 
 	if(seed_time) {

--- a/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSolver.cpp
@@ -45,7 +45,7 @@ namespace Gillespy
 		int critical_threshold = 10;
 
 		std::map<std::string, int> HOR;
-		std::set<Gillespy::Species> reactants;
+		std::set<Gillespy::Species<unsigned int>> reactants;
 
 		std::map<std::string, std::function<double(double)>> g_i_lambdas;
 		std::map<std::string, int> g_i;
@@ -54,7 +54,7 @@ namespace Gillespy
 		std::map<int, std::vector<int>> products;
 	};
 
-	TauArgs initialize(Gillespy::Model &model, double tau_tol)
+	TauArgs initialize(Gillespy::Model<unsigned int> &model, double tau_tol)
 	{
 		// Initialize TauArgs struct to be returned as a pointer
 		TauArgs tau_args;
@@ -139,7 +139,7 @@ namespace Gillespy
 	}
 
 	double select(
-		Gillespy::Model &model,
+		Gillespy::Model<unsigned int> &model,
 		TauArgs &tau_args,
 		const double &tau_tol,
 		const double &current_time,
@@ -289,7 +289,7 @@ namespace Gillespy
 	}
 
 	std::pair<std::map<std::string, int>, double> get_reactions(
-		const Gillespy::Model *model,
+		const Gillespy::Model<unsigned int> *model,
 		const std::vector<double> &propensity_values,
 		double tau_step,
 		double current_time,

--- a/gillespy2/solvers/cpp/c_base/template/template.cpp
+++ b/gillespy2/solvers/cpp/c_base/template/template.cpp
@@ -27,10 +27,10 @@
 
 namespace Gillespy
 {
-	unsigned int populations[GPY_NUM_SPECIES] = GPY_INIT_POPULATIONS;
-	std::vector<unsigned int> species_populations(
+	double populations[GPY_NUM_SPECIES] = GPY_INIT_POPULATIONS;
+	std::vector<double> species_populations(
 		populations,
-		populations + sizeof(populations) / sizeof(unsigned int));
+		populations + sizeof(populations) / sizeof(double));
 
 	std::string s_names[GPY_NUM_SPECIES] = 
 	{
@@ -118,7 +118,8 @@ namespace Gillespy
 		}
 	}
 
-	void add_reactions(Model &model)
+	template <typename T>
+	void add_reactions(Model<T> &model)
 	{
 		unsigned int rxn_i;
 		unsigned int spec_i;
@@ -138,4 +139,7 @@ namespace Gillespy
 
 		model.update_affected_reactions();
 	}
+
+	template void add_reactions<double>(Model<double> &model);
+	template void add_reactions<unsigned int>(Model<unsigned int> &model);
 }

--- a/gillespy2/solvers/cpp/c_base/template/template.h
+++ b/gillespy2/solvers/cpp/c_base/template/template.h
@@ -26,15 +26,20 @@
 
 namespace Gillespy
 {
-	extern std::vector<unsigned int> species_populations;
+	extern std::vector<double> species_populations;
 	extern std::vector<std::string> species_names;
 	extern std::vector<std::string> reaction_names;
 
 	double map_propensity(int reaction_id, const std::vector<int> &state);
 	double map_propensity(int reaction_id, unsigned int *S);
 	double map_ode_propensity(int reaction_id, const std::vector<double> &state);
-	void add_reactions(Model &model);
+
+	template <typename T>
+	void add_reactions(Model<T> &model);
 
 	void map_variable_parameters(std::stringstream &stream);
 	void map_variable_populations(std::stringstream &stream);
+
+	extern template void add_reactions<double>(Model<double> &model);
+	extern template void add_reactions<unsigned int>(Model<unsigned int> &model);
 }


### PR DESCRIPTION
Passing a `double` value as an initial population causes compiler errors in certain environments (most notably StochSS), which causes a solver to fail at the build step.

The solution was to store the initial populations vector as doubles, and allow solvers to convert to the correct data type themselves. This is done via a templated `static_cast` assertion in the C++ model's constructor. Tested locally against StochSS with the Lotka-Volterra and Oregonator models.

Closes #572 