### PR TITLE
Cpp sanitization improvements

### DIFF
--- a/gillespy2/solvers/cpp/build/template_gen.py
+++ b/gillespy2/solvers/cpp/build/template_gen.py
@@ -24,15 +24,13 @@ class SanitizedModel:
     """
     Utility class for preparing a model to be passed to a C++ solver.
     Ensures that any sanitized mappings are consistent between different mappings.
-
     Wraps around an existing GillesPy2 model to provide sanitized mappings.
+
+    :param model: GillesPy2 model to produce sanitized mappings of.
+    :type model: gillespy2.Model
     """
 
     def __init__(self, model: Model):
-        """
-        :param model: GillesPy2 model to produce sanitized mappings of.
-        :type model: gillespy2.Model
-        """
         self.species: "OrderedDict[str, Species]" = OrderedDict()
         self.species_names = model.sanitized_species_names()
         for species_name, sanitized_name in self.species_names.items():
@@ -45,22 +43,24 @@ class SanitizedModel:
                 if parameter_name != "vol" else Parameter(name="V", expression=model.volume)
 
         self.propensities: "OrderedDict[str, str]" = OrderedDict()
+        self.ode_propensities: "OrderedDict[str, str]" = OrderedDict()
         self.reactions: "OrderedDict[str, dict[str, int]]" = OrderedDict()
         for reaction_name, reaction in model.get_all_reactions().items():
-            sanitized_name = model._listOfReactions[reaction_name].name
-            self.propensities[sanitized_name] = reaction.sanitized_propensity_function(
-                self.species_names, self.parameter_names)
+            self.propensities[reaction_name] = reaction.sanitized_propensity_function(
+                self.species_names, self.parameter_names, ode=False)
+            self.ode_propensities[reaction_name] = reaction.sanitized_propensity_function(
+                self.species_names, self.parameter_names, ode=True)
 
-            self.reactions[sanitized_name] = {spec: 0 for spec in self.species_names.values()}
+            self.reactions[reaction_name] = {spec: int(0) for spec in self.species_names.values()}
             for reactant, stoich_value in reaction.reactants.items():
                 if isinstance(reactant, Species):
                     reactant = self.species_names[reactant.name]
-                self.reactions[sanitized_name][reactant] -= stoich_value
+                self.reactions[reaction_name][reactant] -= int(stoich_value)
 
             for product, stoich_value in reaction.products.items():
                 if isinstance(product, Species):
                     product = self.species_names[product.name]
-                self.reactions[sanitized_name][product] += stoich_value
+                self.reactions[reaction_name][product] += int(stoich_value)
 
 
 def write_template(path: str, model: Model, variable=False):
@@ -99,78 +99,39 @@ def get_model_defines(model: Model, variable=False) -> "dict[str, str]":
     :returns: Dictionary of fully-formatted macro definitions.
     """
     results = {}
+    sanitized_model = SanitizedModel(model)
 
     # Get definitions for variables
-    parameter_mappings = model.sanitized_parameter_names()
-    parameters = []
-    parameter_names = []
-    # System volume needs to be added manually.
-    # It is assumed to ALWAYS be the first parameter.
-    if model.volume:
-        parameters.append(Parameter(name="V", expression=model.volume))
-        parameter_names.append("V")
-    for p_name, param in model.get_all_parameters().items():
-        parameters.append(param)
-        parameter_names.append(parameter_mappings[p_name])
-    parameter_definitions = template_def_variables(parameters, parameter_names, variable)
+    parameter_definitions = template_def_variables(sanitized_model, variable)
     results.update(parameter_definitions)
 
     # Get definitions for species
-    species = []
-    species_names = []
-    species_map = OrderedDict()
-    for spec_id, spec_entry in enumerate(model.get_all_species().items()):
-        spec_name, spec = spec_entry
-        species.append(spec)
-        species_names.append(spec_name)
-        species_map[spec_name] = spec_id
-    species_definitions = template_def_species(species, species_names)
+    species_definitions = template_def_species(sanitized_model)
     results.update(species_definitions)
 
     # Get definitions for reactions
-    reaction_bases = model.get_all_reactions()
-    reaction_names = []
-    reactions = []
-    for rxn_name, rxn in reaction_bases.items():
-        reaction_names.append(rxn_name)
-        reactions.append(rxn)
-    reaction_definitions = template_def_reactions(reactions, reaction_names, species_map)
+    reaction_definitions = template_def_reactions(sanitized_model)
     results.update(reaction_definitions)
-    
+
     # Get definitions for propensities
-    stoch_propensities = []
-    ode_propensities = []
-    for rxn in reactions:
-        # ODE and non-ODE propensities can sometimes differ.
-        # As a result, each one needs to be sanitized and evaluated separately.
-        stoch_propensity = rxn.sanitized_propensity_function(
-            model.sanitized_species_names(),
-            model.sanitized_parameter_names(),
-            ode=False)
-        ode_propensity = rxn.sanitized_propensity_function(
-            model.sanitized_species_names(),
-            model.sanitized_parameter_names(),
-            ode=True)
-        stoch_propensities.append(stoch_propensity)
-        ode_propensities.append(ode_propensity)
-    stoch_propensity_definitions = template_def_propensities(stoch_propensities, ode=False)
-    ode_propensity_definitions = template_def_propensities(ode_propensities, ode=True)
+    stoch_propensity_definitions = template_def_propensities(sanitized_model, ode=False)
+    ode_propensity_definitions = template_def_propensities(sanitized_model, ode=True)
     results.update(stoch_propensity_definitions)
     results.update(ode_propensity_definitions)
 
     return results
 
-def template_def_variables(parameters: "list[Parameter]", sanitized_names: "list[str]", variable=False) -> "dict[str, str]":
+
+def template_def_variables(model: SanitizedModel, variable=False) -> "dict[str, str]":
     """
     Formats the relevant parameters to be passed to a C++ simulation template.
     Passed dictionaries/lists are assumed to be sanitized and sorted.
-    
-    :param parameters: Ordered list of runtime parameters.
-    :type parameters: list[gillespy2.Parameter]
 
-    :param sanitized_names: Ordered list of names for their corresponding runtime parameters.
-        sanitized_names[i] should match parameters[i].
-    :type sanitized_names: list[str]
+    :param model: Sanitized model containing runtime definitions.
+    :type model: SanitizedModel
+
+    :param variable: Indicates whether the model's variables should be modifiable at runtime.
+    :type variable: bool
 
     :returns: The result as a list of tuples containing key-value pairs to be templated.
     """
@@ -178,36 +139,33 @@ def template_def_variables(parameters: "list[Parameter]", sanitized_names: "list
     parameter_type = "VARIABLE" if variable else "CONSTANT"
     # Parameter entries, parsed and formatted
     parameter_set = []
-    for param_id, parameter in enumerate(parameters):
-        name = sanitized_names[param_id]
-
-        parameter_set.append(f"{parameter_type}({name},{parameter.value})")
+    for param_name, parameter in model.parameters.items():
+        parameter_set.append(f"{parameter_type}({param_name},{parameter.expression})")
 
     return {
         "GPY_PARAMETER_VALUES": " ".join(parameter_set)
     }
 
-def template_def_species(species: "list[Species]", sanitized_names: "list[str]") -> "dict[str, str]":
+
+def template_def_species(model: SanitizedModel) -> "dict[str, str]":
     """
     Passed dictionaries/lists are assumed to be sanitized and sorted.
     Formats the relevant species data to be passed to a C++ simulation template.
 
-    :param species: Ordered list of species.
-    :type species: gillespy2.Species
-
-    :param sanitized_names: Ordered list of names corresponding to species.
-        sanitized_names[i] should map to species[i].
-    :type sanitized_names: list[str]
+    :param model: Sanitized model containing runtime definitions.
+    :type model: SanitizedModel
 
     :returns: Dictionary of macro definitions for species and data related to species.
     """
     # Parse and format species initial populations
-    populations = [str(specimen.initial_value) for specimen in species]
-    num_species = str(len(populations))
+    num_species = len(model.species)
+    populations = OrderedDict()
 
+    for spec_name, spec in model.species.items():
+        populations[spec_name] = str(spec.initial_value)
     # Species names, parsed and formatted
-    sanitized_names = [f"SPECIES_NAME({name})" for name in sanitized_names]
-    populations = f"{{{','.join(populations)}}}"
+    sanitized_names = [f"SPECIES_NAME({name})" for name in populations.keys()]
+    populations = f"{{{','.join(populations.values())}}}"
 
     # Match each parameter with its macro definition name
     return {
@@ -216,76 +174,46 @@ def template_def_species(species: "list[Species]", sanitized_names: "list[str]")
         "GPY_SPECIES_NAMES": " ".join(sanitized_names)
     }
 
-def template_def_reactions(reactions: "list[Reaction]", sanitized_names: "list[str]", species_map: "OrderedDict[str, int]") -> "dict[str, str]":
+
+def template_def_reactions(model: SanitizedModel, ode=False) -> "dict[str, str]":
     """
     Passed dictionaries/lists are assumed to be sanitized and sorted.
     Formats the relevant reactions and propensities to be passed to a C++ simulation template.
 
-    :param reactions: Ordered list of reactions.
-        The reaction's index in this list should correspond to its reaction id.
-        For example, the reaction at reactions[3] has id 3.
-    :type reactions: list[Reaction]
-
-    :param sanitized_names: Ordered list of sanitized names for the reactions.
-        The name's index in this list should match its corresponding reaction.
-        sanitized_names[i] is matched to reactions[i].
-    :type sanitized_names: list[str]
-
-    :param species_map: Ordered dictionary mapping an unsanitized species name to its id.
-    :type species_map: OrderedDict[str, int]
+    :param model: Sanitized model containing runtime definitions.
+    :type model: SanitizedModel
 
     :returns: Dictionary of macro definitions for reactions.
     """
-    num_reactions = str(len(reactions))
-    reaction_set = []
-    reaction_names = []
+    num_reactions = str(len(model.reactions))
+    reaction_set = OrderedDict()
 
-    for rxn_id, reaction in enumerate(reactions):
-        name = sanitized_names[rxn_id]
-        reaction_names.append(f"REACTION_NAME({name})")
-        # Get stoichiometry matrix of reaction, turn into string, append to reacton_set
-        species_change = [0] * len(species_map)
+    for rxn_name, reaction in model.reactions.items():
+        stoich = [str(int(reaction[species])) for species in model.species_names.values()]
+        reaction_set[rxn_name] = f"{{{','.join(stoich)}}}"
 
-        for reactant, stoich in reaction.reactants.items():
-            spec_id = species_map[reactant.name]
-            species_change[spec_id] -= int(stoich)
-
-        for product, stoich in reaction.products.items():
-            spec_id = species_map[product.name]
-            species_change[spec_id] += int(stoich)
-
-        # Format the species changes as a stoichiometry set
-        species_change = [str(dx) for dx in species_change]
-        stoich = ",".join(species_change)
-        reaction_set.append(f"{{{stoich}}}")
-
-    reaction_set = f"{{{','.join(reaction_set)}}}"
-    reaction_names = " ".join(reaction_names)
+    reaction_names = " ".join([f"REACTION_NAME({rxn})" for rxn in reaction_set.keys()])
+    reaction_set = f"{{{','.join(reaction_set.values())}}}"
 
     return {
         "GPY_NUM_REACTIONS": num_reactions,
         "GPY_REACTIONS": reaction_set,
-        "GPY_REACTION_NAMES": reaction_names
+        "GPY_REACTION_NAMES": reaction_names,
     }
 
-def template_def_propensities(sanitized_propensities: "list[str]", ode=False) -> "dict[str, str]":
+
+def template_def_propensities(model: SanitizedModel, ode=False) -> "dict[str, str]":
     """
     Formats the given list of pre-sorted, pre-sanitized propensities.
 
-    :param sanitized_propensities: Ordered list of strings containing propensity functions.
-    :type sanitized_propensities: list[str]
-
-    :param ode: Boolean indicating whether the provided propensities are stochastic or deterministic.
-        If set to True, then propensities will be assumed to be ODE propensities.
-    :type ode: bool
+    :param model: Sanitized model containing runtime definitions.
+    :type model: SanitizedModel
 
     :returns: Dictionary containing propensity macro definitions.
     """
     def_keyword = "ODE_PROPENSITIES" if ode else "PROPENSITIES"
-    propensities = []
-
-    for prop_id, prop in enumerate(sanitized_propensities):
-        propensities.append(f"PROPENSITY({prop_id},{prop})")
+    propensities = model.ode_propensities if ode else model.propensities
+    propensities = [f"PROPENSITY({rxn_i},{propensities[rxn]})" for rxn_i, rxn in enumerate(model.reactions.keys())]
 
     return {
         f"GPY_{def_keyword}": " ".join(propensities)


### PR DESCRIPTION
Implements an internally used `SanitizedModel` class which converts a GillesPy2 model into a pre-sanitized collection. The goal here is to use `SanitizedModel` as a "single source of truth" for getting sanitized model strings when running C++ solvers. We assume that the model's own structures are not to be trusted, opting instead to generate the sanitized mappings ourselves. By doing so, we ensure that Reactions referencing Species or Parameters are accurate and correctly ordered.

This removes a lot of the edge cases involved with converting a model into its corresponding `template_definitions.h` file, and allows us to make sanitization optimizations in one place.

Closes #545 