### PR TITLE
Cleanup compiler warnings from C++ solvers

### DIFF
--- a/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
+++ b/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
@@ -31,16 +31,16 @@ namespace Gillespy
 		TauArgs<PType> tau_args;
 
 		// Initialize highest order rxns to 0
-		for (int i = 0; i < model.number_species; i++)
+		for (unsigned int i = 0; i < model.number_species; i++)
 		{
 			tau_args.HOR[model.species[i].name] = 0;
 		}
 
-		for (int r = 0; r < model.number_reactions; r++)
+		for (unsigned int r = 0; r < model.number_reactions; r++)
 		{
 			int rxn_order = 0;
 
-			for (int spec = 0; spec < model.number_species; spec++)
+			for (unsigned int spec = 0; spec < model.number_species; spec++)
 			{
 				if (model.reactions[r].species_change[spec] > 0)
 				{
@@ -132,14 +132,14 @@ namespace Gillespy
 		std::map<std::string, double> sigma_i;
 
 		// initialize mu_i and sigma_i to 0
-		for (int spec = 0; spec < model.number_species; spec++)
+		for (unsigned int spec = 0; spec < model.number_species; spec++)
 		{
 			mu_i[model.species[spec].name] = 0;
 			sigma_i[model.species[spec].name] = 0;
 		}
 
 		// Determine if there are any critical reactions, update mu_i and sigma_i
-		for (int reaction = 0; reaction < model.number_reactions; reaction++)
+		for (unsigned int reaction = 0; reaction < model.number_reactions; reaction++)
 		{
 			for (auto const &reactant : tau_args.reactions_reactants[reaction])
 			{
@@ -164,9 +164,9 @@ namespace Gillespy
 
 		// If a critical reaction is present, estimate tau for a single firing of each
 		// critical reaction with propensity > 0, and take the smallest tau
-		if (critical == true)
+		if (critical)
 		{
-			for (int reaction = 0; reaction < model.number_reactions; reaction++)
+			for (unsigned int reaction = 0; reaction < model.number_reactions; reaction++)
 			{
 				if (propensity_values[reaction] > 0)
 				{
@@ -210,7 +210,7 @@ namespace Gillespy
 			}
 		}
 
-		if (tau_i.size() > 0)
+		if (tau_i.empty())
 		{
 			//find min of tau_i
 			std::pair<std::string, double> min;
@@ -223,13 +223,13 @@ namespace Gillespy
 		}
 
 		// If all reactions are non-critical, use non-critical tau.
-		if (critical == false)
+		if (critical)
 		{
 			tau = non_critical_tau;
 		}
 
 		// If all reactions are critical, use critical tau.
-		else if (tau_i.size() == 0)
+		else if (tau_i.empty())
 		{
 			tau = critical_tau;
 		}

--- a/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
+++ b/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
@@ -229,7 +229,7 @@ namespace Gillespy
 		}
 
 		// If all reactions are critical, use critical tau.
-		else if (!tau_i.empty())
+		else if (tau_i.empty())
 		{
 			tau = critical_tau;
 		}

--- a/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
+++ b/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
@@ -223,7 +223,7 @@ namespace Gillespy
 		}
 
 		// If all reactions are non-critical, use non-critical tau.
-		if (critical)
+		if (!critical)
 		{
 			tau = non_critical_tau;
 		}

--- a/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
+++ b/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
@@ -210,7 +210,7 @@ namespace Gillespy
 			}
 		}
 
-		if (tau_i.empty())
+		if (!tau_i.empty())
 		{
 			//find min of tau_i
 			std::pair<std::string, double> min;
@@ -229,7 +229,7 @@ namespace Gillespy
 		}
 
 		// If all reactions are critical, use critical tau.
-		else if (tau_i.empty())
+		else if (!tau_i.empty())
 		{
 			tau = critical_tau;
 		}

--- a/gillespy2/solvers/cpp/c_base/model.cpp
+++ b/gillespy2/solvers/cpp/c_base/model.cpp
@@ -128,11 +128,11 @@ namespace Gillespy {
 
 	template <typename TNum>
 	void Simulation<TNum>::output_results_buffer(std::ostream &os) {
-		for (int trajectory = 0; trajectory < number_trajectories; trajectory++) {
-			for (int timestep = 0; timestep < number_timesteps; timestep++) {
+		for (unsigned int trajectory = 0; trajectory < number_trajectories; trajectory++) {
+			for (unsigned int timestep = 0; timestep < number_timesteps; timestep++) {
 				os << timeline[timestep] << ',';
 
-				for (int species = 0; species < model->number_species; species++) {
+				for (unsigned int species = 0; species < model->number_species; species++) {
 					os << trajectories[trajectory][timestep][species] << ',';
 				}
 			}

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
@@ -134,10 +134,11 @@ namespace Gillespy::TauHybrid
 		std::vector<HybridReaction> &reactions,
 		std::vector<HybridSpecies> &species)
 	{
+		unsigned int num_reactions = reactions.size();
 		unsigned int num_species = species.size();
 		std::set<unsigned int> det_rxns;
 
-		for (unsigned int rxn_i = 0; rxn_i < num_species; ++rxn_i) {
+		for (unsigned int rxn_i = 0; rxn_i < num_reactions; ++rxn_i) {
 			// start with the assumption that reaction is determinstic
 			HybridReaction &rxn = reactions[rxn_i];
 			rxn.mode = SimulationState::CONTINUOUS;

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
@@ -28,7 +28,7 @@
 namespace Gillespy::TauHybrid
 {
 
-	typedef int ReactionId;
+	typedef unsigned int ReactionId;
 
 	/* Gillespy::TauHybrid::DiffEquation
 	 * A vector containing evaluable functions, which accept integrator state and return propensities.
@@ -99,10 +99,10 @@ namespace Gillespy::TauHybrid
 		std::vector<HybridReaction> reaction_state;
 
 		HybridSimulation();
-		HybridSimulation(const Model<double> &model);
+		explicit HybridSimulation(const Model<double> &model);
 	};
 
-	std::set<int> flag_det_rxns(
+	std::set<unsigned int> flag_det_rxns(
 		std::vector<HybridReaction> &reactions,
 		std::vector<HybridSpecies> &species);
 

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
@@ -54,9 +54,8 @@ namespace Gillespy::TauHybrid
 		std::vector<int> populations;
 		std::vector<double> propensities;
 
-		IntegratorData(HybridSimulation *simulation);
-		IntegratorData(HybridSimulation *simulation, int num_species, int num_reactions);
-		IntegratorData(IntegratorData &prev_data);
+		explicit IntegratorData(HybridSimulation *simulation);
+		IntegratorData(HybridSimulation *simulation, unsigned int num_species, unsigned int num_reactions);
 	};
 
 	/* :IntegrationResults:
@@ -80,15 +79,16 @@ namespace Gillespy::TauHybrid
 	private:
 		void *cvode_mem;
 		N_Vector y0;
-		double t0;
+		double t0 = 0.0f;
 		SUNLinearSolver solver;
-		int num_species;
-		int num_reactions;
+		unsigned int num_species;
+		unsigned int num_reactions;
 	public:
 		// status: check for errors before using the results.
-		IntegrationStatus status;
 		N_Vector y;
-		realtype t;
+		IntegrationStatus status;
+		IntegratorData data;
+		realtype t = 0.0f;
 
 		/* save_state()
 		 * Creates a duplicate copy of the integrator's current solution vector.
@@ -115,7 +115,6 @@ namespace Gillespy::TauHybrid
 		void reinitialize(N_Vector y_reset);
 
 		IntegrationResults integrate(double *t);
-		IntegratorData data;
 
 		Integrator(HybridSimulation *simulation, N_Vector y0, double reltol, double abstol);
 		~Integrator();
@@ -126,10 +125,8 @@ namespace Gillespy::TauHybrid
 	private:
 		std::uniform_real_distribution<double> uniform;
 		std::mt19937_64 rng;
-		unsigned long long seed;
 	public:
 		double next();
-		URNGenerator();
 		explicit URNGenerator(unsigned long long seed);
 	};
 

--- a/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSolver.cpp
@@ -63,7 +63,7 @@ namespace Gillespy
 		std::map<std::string, int> rxn_count; // map of how many times reaction is fired
 		std::pair<std::map<std::string, int>, double> values; // value pair to be returned, map of times {map of times reaction fired, current time}
 
-		for (int i = 0; i < model->number_reactions; i++)
+		for (unsigned int i = 0; i < model->number_reactions; i++)
 		{
 			std::poisson_distribution<int> poisson(propensity_values[i] * tau_step);
 			rxn_count[model->reactions[i].name] = poisson(generator);
@@ -111,7 +111,7 @@ namespace Gillespy
 				break;
 			}
 
-			for (int spec = 0; spec < simulation->model->number_species; spec++)
+			for (unsigned int spec = 0; spec < simulation->model->number_species; spec++)
 			{
 				current_state[spec] = simulation->model->species[spec].initial_population;
 			}
@@ -120,14 +120,8 @@ namespace Gillespy
 			simulation->current_time = 0;
 			unsigned int entry_count = 0;
 
-			//Propensity sum initialization, to be added to later.
-			double propensity_sum;
-
 			//Start save time
 			double save_time = 0;
-
-			//Variable to keep track of rejected steps, debug
-			int steps_rejected = 0;
 
 			//Initialize tau_step, will be assigned using tau::select()
 			double tau_step;
@@ -179,7 +173,7 @@ namespace Gillespy
 
 						std::map<int, bool> species_modified;
 
-						for (int i = 0; i < simulation->model->number_reactions; i++)
+						for (unsigned int i = 0; i < simulation->model->number_reactions; i++)
 						{
 							if (rxn_count[simulation->model->reactions[i].name] > 0)
 							{
@@ -208,7 +202,7 @@ namespace Gillespy
 							}
 						}
 
-						if (neg_state == true)
+						if (neg_state)
 						{
 							current_state = prev_curr_state;
 							simulation->current_time = prev_curr_time;
@@ -221,7 +215,7 @@ namespace Gillespy
 						}
 					}
 				}
-				for (int i = 0; i < simulation->model->number_species; i++)
+				for (unsigned int i = 0; i < simulation->model->number_species; i++)
 				{
 					simulation->trajectories[trajectory_number][entry_count][i] = current_state[i];
 				}


### PR DESCRIPTION
The goal with this PR is to eliminate the unnecessary warnings shown in stderr when compiling the C++ solvers. This way, when an actual error occurs, only the relevant error messages will be shown. This should make debugging and issue management more tolerable.

Most of the warnings were for narrowing of `unsigned int` to `int`, as the simulation data structures store count properties (like `num_trajectories`, `num_species`, etc.) as unsigned. All of the loops which iterate over simulation data structures were switched to `unsigned int`, exclusively.

Other fixes:
- Added `validate()` function to ODE solver to validate `CVode` return code
- Fixed constructor initializer list ordering
- Added explicit casts when converting from concentration values to populations