### PR TITLE
Fix segfault in C++ tau select function

### DIFF
--- a/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
+++ b/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
@@ -189,10 +189,9 @@ namespace Gillespy
 			for (auto const &x : tau_args.g_i_lambdas)
 			{
 				tau_args.g_i[x.first] = tau_args.g_i_lambdas[x.first](tau_args.g_i[x.first]);
-
 				tau_args.epsilon_i[x.first] = tau_tol / tau_args.g_i[x.first];
-				tau_args.g_i_lambdas.erase(x.first);
 			}
+			tau_args.g_i_lambdas.clear();
 		}
 
 		std::map<std::string, double> tau_i;    //Mapping of possible non-critical_taus, to be evaluated


### PR DESCRIPTION
Small fix that gets rid of a seg fault in the Tau select function. Moves the clearing of an `std::map` object to be *after* the iterator, rather than during iteration (which causes memory issues).

Closes #585 