### PR TITLE
tau hybrid solver run timespan fix

### DIFF
--- a/gillespy2/solvers/numpy/tau_hybrid_solver.py
+++ b/gillespy2/solvers/numpy/tau_hybrid_solver.py
@@ -858,6 +858,7 @@ class TauHybridSolver(GillesPySolver):
 
         # create numpy array for timeline
         timeline = np.linspace(0, t, int(round(t / increment + 1)))
+        model.tspan = timeline
 
         # create numpy matrix to mark all state data of time and species
         trajectory_base = np.zeros((number_of_trajectories, timeline.size, number_species + 1))


### PR DESCRIPTION
Tau Hybrid Solver was mixing up model timespan and kwarg timespan when run using solver.run instead of model.run.  Now, when using solver.run(), solver will implement kwarg t and increment replicating the behavior of other solvers