### PR TITLE
Bug fixes for multi-event models

### DIFF
--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
@@ -604,12 +604,6 @@ namespace Gillespy
 				m_trigger_pool.erase(event.get_event_id());
 			}
 
-			// Step 5: Update any trigger states to reflect the new trigger value.
-			for (auto &event : m_events)
-			{
-				m_trigger_state.find(event.get_event_id())->second = event.trigger(t, event_state);
-			}
-
 			return has_active_events();
 		}
 	}

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
@@ -88,7 +88,7 @@ namespace Gillespy
 			}
 
 			inline bool is_persistent() const { return m_use_persist; }
-			inline bool get_event_id() const { return m_event_id; }
+			inline int get_event_id() const { return m_event_id; }
 
 			EventExecution get_execution(double t,
 					const double *state, int num_state) const;

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
@@ -143,6 +143,10 @@ IntegrationResults Integrator::integrate(double *t)
 IntegrationResults Integrator::integrate(double *t, std::set<int> &event_roots, std::set<unsigned int> &reaction_roots)
 {
 	IntegrationResults results = integrate(t);
+	if (status != IntegrationStatus::OK) {
+		return results;
+	}
+
 	unsigned long long num_triggers = data.active_triggers.size();
 	unsigned long long num_rxn_roots = data.active_reaction_ids.size();
 	unsigned long long root_size = data.active_triggers.size() + data.active_reaction_ids.size();


### PR DESCRIPTION
# Bug Fixes
- Fixed a bug where models with >2 events failed due to the event id being converted from `int` to `bool`, limiting the event id pool to {0,1}.
- Fixed a bug where integrator errors were not being validated.