### PR TITLE
Pause-resume patch fixes

### DIFF
--- a/gillespy2/solvers/cpp/build/template_gen.py
+++ b/gillespy2/solvers/cpp/build/template_gen.py
@@ -368,7 +368,7 @@ def template_def_species(model: SanitizedModel) -> "dict[str, str]":
     populations = OrderedDict()
 
     for spec_name, spec in model.species.items():
-        populations[spec_name] = str(spec.initial_value)
+        populations[spec_name] = str(float(spec.initial_value))
     # Species names, parsed and formatted
     sanitized_names = [f"SPECIES_NAME({name})" for name in populations.keys()]
     populations = f"{{{','.join(populations.values())}}}"

--- a/gillespy2/solvers/cpp/c_base/model.cpp
+++ b/gillespy2/solvers/cpp/c_base/model.cpp
@@ -147,7 +147,7 @@ namespace Gillespy {
 				os << timeline[timestep] << ',';
 
 				for (int species = 0; species < model->number_species; species++) {
-					os << trajectories[trajectory][timestep][species] << ',';
+					os << (double) trajectories[trajectory][timestep][species] << ',';
 				}
 			}
 		}

--- a/gillespy2/solvers/cpp/c_base/model.h
+++ b/gillespy2/solvers/cpp/c_base/model.h
@@ -26,6 +26,14 @@
 #include <vector>
 #include <iostream>
 
+#if defined(WIN32) || defined(WIN32) || defined(__WIN32) || defined(__WIN32__)
+#include <windows.h>
+#define GPY_PID_GET() ((int) GetCurrentProcessId())
+#else
+#include <unistd.h>
+#define GPY_PID_GET() (getpid())
+#endif
+
 namespace Gillespy
 {
 	typedef unsigned int ReactionId;

--- a/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESimulation.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[]) {
 
 	if (seed_time)
 	{
-		random_seed = time(NULL);
+		random_seed = time(nullptr) % GPY_PID_GET();
 	}
 
 	Simulation<double> simulation;

--- a/gillespy2/solvers/cpp/c_base/ssa_cpp_solver/SSASimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/ssa_cpp_solver/SSASimulation.cpp
@@ -59,7 +59,7 @@ int main(int argc, char *argv[])
 	
 	if (seed_time)    
 	{
-		random_seed = time(NULL);
+		random_seed = time(nullptr) % GPY_PID_GET();
 	}
 
 	Simulation<unsigned int> simulation;

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
 	add_reactions(model);
 
 	if(seed_time){
-		random_seed = time(nullptr) % getpid();
+		random_seed = time(nullptr) % GPY_PID_GET();
 	}
 	//Simulation INIT
 	TauHybrid::HybridSimulation simulation(model);

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
@@ -53,7 +53,7 @@ int main(int argc, char* argv[])
 	add_reactions(model);
 
 	if(seed_time){
-		random_seed = time(NULL);
+		random_seed = time(nullptr) % getpid();
 	}
 	//Simulation INIT
 	TauHybrid::HybridSimulation simulation(model);

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
@@ -217,10 +217,6 @@ bool Integrator::disable_root_finder()
 	return validate(this, CVodeRootInit(cvode_mem, 0, NULL));
 }
 
-
-URNGenerator::URNGenerator()
-	: uniform(0, 1) {}
-
 URNGenerator::URNGenerator(unsigned long long seed)
 	: uniform(0, 1),
 	  rng(seed)

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
@@ -170,7 +170,7 @@ namespace Gillespy
 		unsigned long long seed;
 	public:
 		double next();
-		URNGenerator();
+		URNGenerator() = delete;
 		explicit URNGenerator(unsigned long long seed);
 	};
 

--- a/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_leaping_cpp_solver/TauLeapingSimulation.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[]){
 	add_reactions(model);
 
 	if(seed_time) {
-		random_seed = time(NULL);
+		random_seed = time(nullptr) % GPY_PID_GET();
 	}
 	Simulation<unsigned int> simulation;
 

--- a/gillespy2/solvers/utilities/solverutils.py
+++ b/gillespy2/solvers/utilities/solverutils.py
@@ -91,19 +91,19 @@ def update_species_init_values(listOfSpecies, species, variables, resume = None)
     populations = ''
     for i in range(len(species) - 1):
         if species[i] in variables:
-            populations += '{} '.format(int(variables[species[i]]))
+            populations += '{} '.format(float(variables[species[i]]))
         else:
             if resume is not None:
-                populations += '{} '.format(int(resume[species[i]][-1]))
+                populations += '{} '.format(float(resume[species[i]][-1]))
             else:
-                populations += '{} '.format(int(listOfSpecies[species[i]].initial_value))
+                populations += '{} '.format(float(listOfSpecies[species[i]].initial_value))
     if species[-1] in variables:
-        populations += '{}'.format(int(variables[species[-1]]))
+        populations += '{}'.format(float(variables[species[-1]]))
     else:
         if resume is not None:
-            populations += '{} '.format(int(resume[species[-1]][-1]))
+            populations += '{} '.format(float(resume[species[-1]][-1]))
         else:
-            populations += '{}'.format(int(listOfSpecies[species[-1]].initial_value))
+            populations += '{}'.format(float(listOfSpecies[species[-1]].initial_value))
     return populations
 
 def change_param_values(listOfParameters, parameters, volume, variables):


### PR DESCRIPTION
Temporary fixes for pause-resume behavior in C++ solvers.

## Fixes

- Fixed repeated output on pause-resume, caused by identical seeds between runs
  - Uses simulation process id as part of seed
  - Note: `getpid()` is deprecated on Windows, so getting the process id is platform-specific
- Fixed rounding issue for variable solvers by passing command-line args as floats rather than ints