### PR TITLE
Improve expression error handling

### DIFF
--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -70,7 +70,7 @@ class EventAssignment(Jsonify):
                              'valid string expression')
 
     def __str__(self):
-        return self.variable.name + ': ' + self.expression
+        return f"{self.variable}: {self.expression}"
 
 class EventTrigger(Jsonify):
     """

--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -841,7 +841,8 @@ class Model(SortableObject, Jsonify):
             return self.get_assignment_rule(ename)
         if ename in self.listOfFunctionDefinitions:
             return self.get_function_definition(ename)
-        return 'Element not found!'
+        #return 'Element not found!'
+        raise ModelError(f"model.get_element(): element={ename} not found")
 
 
     def get_best_solver(self):

--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -841,7 +841,6 @@ class Model(SortableObject, Jsonify):
             return self.get_assignment_rule(ename)
         if ename in self.listOfFunctionDefinitions:
             return self.get_function_definition(ename)
-        #return 'Element not found!'
         raise ModelError(f"model.get_element(): element={ename} not found")
 
 

--- a/gillespy2/solvers/cpp/build/template_gen.py
+++ b/gillespy2/solvers/cpp/build/template_gen.py
@@ -39,6 +39,12 @@ class SanitizedModel:
         "t": "t",
     }
 
+    # Global functions that aren't present in the `math` package,
+    # as well as functions in Python that have a different name in C++.
+    function_map = {
+        "abs": "abs",
+    }
+
     def __init__(self, model: Model, variable=False):
         self.model = model
         self.variable = variable
@@ -68,6 +74,7 @@ class SanitizedModel:
             # All "system" namespace entries should always be first.
             # Otherwise, user-defined identifiers (like, for example, "gamma") might get overwritten.
             **{name: name for name in math.__dict__.keys()},
+            **self.function_map,
             **self.species_names,
             **self.parameter_names,
             **self.reserved_names,

--- a/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
+++ b/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
@@ -93,7 +93,8 @@ class TauHybridCSolver(GillesPySolver, CSolver):
                     elif variable in sanitized_model.model.listOfParameters:
                         variable = sanitized_model.model.listOfParameters.get(variable)
                     else:
-                        raise ValueError(f"Invalid event assignment {assign}: received name {variable} "
+                        raise ValueError(f"Error in event={event} "
+                                         f"Invalid event assignment {assign}: received name {variable} "
                                          f"Must match the name of a valid Species or Parameter.")
 
                 if isinstance(variable, gillespy2.Species):

--- a/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
+++ b/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
@@ -108,6 +108,17 @@ class TauHybridCSolver(GillesPySolver, CSolver):
                 assignments.append(str(assign_id))
                 event_assignment_list.append(assign_str)
                 assign_id += 1
+            # Check for "None"s
+            for a in assignments:
+                if a is None: raise Exception(f"a is Nonein event={event}")
+            if event_id is None: raise Exception(f"event_id is None in event={event}")
+            if trigger is None: raise Exception(f"trigger is None in event={event}")
+            if delay is None: raise Exception(f"delay is None in event={event}")
+            if priority is None: raise Exception(f"priority is None in event={event}")
+            if use_trigger is None: raise Exception(f"use_trigger is None in event={event}")
+            if use_persist is None: raise Exception(f"use_persist is None in event={event}")
+            if initial_value is None: raise Exception(f"initial_value is None in event={event}")
+
             assignments: "str" = " AND ".join(assignments)
             event_list.append(
                 f"EVENT("

--- a/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
+++ b/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
@@ -110,7 +110,7 @@ class TauHybridCSolver(GillesPySolver, CSolver):
                 assign_id += 1
             # Check for "None"s
             for a in assignments:
-                if a is None: raise Exception(f"a is Nonein event={event}")
+                if a is None: raise Exception(f"assignment={a} is None in event={event}")
             if event_id is None: raise Exception(f"event_id is None in event={event}")
             if trigger is None: raise Exception(f"trigger is None in event={event}")
             if delay is None: raise Exception(f"delay is None in event={event}")

--- a/gillespy2/solvers/utilities/solverutils.py
+++ b/gillespy2/solvers/utilities/solverutils.py
@@ -19,6 +19,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import ast  # for dependency graphing
 import numpy as np
 from gillespy2.core import log, Species
+from gillespy2.core import ModelError
 
 """
 NUMPY SOLVER UTILITIES BELOW
@@ -143,8 +144,11 @@ def species_parse(model, custom_prop_fun):
 
     class SpeciesParser(ast.NodeTransformer):
         def visit_Name(self, node):
-            if isinstance(model.get_element(node.id), Species):
-                parsed_species.append(model.get_element(node.id))
+            try:
+                if isinstance(model.get_element(node.id), Species):
+                    parsed_species.append(model.get_element(node.id))
+            except ModelError:
+                pass
 
     expr = custom_prop_fun
     expr = ast.parse(expr, mode='eval')


### PR DESCRIPTION
(See issue #687)

Improves the error handling of the `Expression` class, and allows for adding Python built-ins to be mapped to C++ ones.

# Fixes
- `Expression#getexpr_cpp` and `Expression#getexpr_python` raise a `SyntaxError` on parsing validation errors, instead of returning `None`.
- Adds the Python `abs` function as a valid function identifier in `Expression` code.
  - Additional Python built-ins can be introduced by adding an entry to the `Expression.function_map` dictionary, where the key is the name of the Python function and the value is the C++ equivalent (they can, and often are, the same).

Closes #688