### PR TITLE
Add correct C++ solver names for validation errors

### DIFF
--- a/gillespy2/solvers/cpp/c_solver.py
+++ b/gillespy2/solvers/cpp/c_solver.py
@@ -372,7 +372,9 @@ class CSolver:
                 detected.append(feature_name)
 
         if len(detected):
-            raise gillespyError.ModelError(f"Could not run Model.  SBML Feature: {detected} not supported by SSACSolver.")
+            raise gillespyError.ModelError(f"Could not run Model, "
+                                           f"SBML Features not supported by {self.name}: "
+                                           + ", ".join(detected))
 
     def _validate_seed(self, seed: int):
         if seed is None:


### PR DESCRIPTION
The C++ solvers use the wrong solver name when raising a `SimulationError` due to unsupported SBML features. To fix, the hard-coded name "SSACSolver" is substituted with the `name` property of the target solver.

Replicate by creating a model using one or more unsupported SBML objects:

```python
import gillespy2

class TestModel(gillespy2.Model):
    def __init__(self):
        super().__init__(name="TestModel")
        self.add_species(gillespy2.Species(name="S", initial_value=0))
        self.add_assignment_rule(gillespy2.AssignmentRule(variable="S", formula="t"))
        self.add_function_definition(gillespy2.FunctionDefinition(name="f", function="x", args=["x"]))

# Raises an error, should now have the correct target name in error message
gillespy2.TauHybridCSolver(model=TestModel()).run()
```

Closes #698 