### PR TITLE
Fix multi-trajectory bug in `TauHybridCSolver`

### DIFF
--- a/gillespy2/solvers/cpp/c_base/model.cpp
+++ b/gillespy2/solvers/cpp/c_base/model.cpp
@@ -88,19 +88,6 @@ namespace Gillespy {
 	void init_simulation(Model<TNum> *model, Simulation<TNum> &simulation) {
 		init_timeline(model, simulation);
 
-		unsigned int trajectory_size = simulation.number_timesteps * (model->number_species);
-		simulation.trajectories_1D = new TNum[simulation.number_trajectories * trajectory_size];
-		simulation.trajectories = new TNum * *[simulation.number_trajectories];
-
-		for (unsigned int trajectory = 0; trajectory < simulation.number_trajectories; trajectory++) {
-			simulation.trajectories[trajectory] = new TNum * [simulation.number_timesteps];
-
-			for (unsigned int timestep = 0; timestep < simulation.number_timesteps; timestep++) {
-				simulation.trajectories[trajectory][timestep] =
-					&(simulation.trajectories_1D[trajectory * trajectory_size + timestep * (model->number_species)]);
-			}
-		}
-
 		simulation.current_state = new TNum[model->number_species];
 		// Output interval must lie within the range (0, num_timesteps].
 		// An output interval of 0 signifies to output entire trajectories.
@@ -113,13 +100,7 @@ namespace Gillespy {
 	template <typename TNum>
 	Simulation<TNum>::~Simulation() {
 		delete[] timeline;
-		delete[] trajectories_1D;
-
-		for (unsigned int trajectory = 0; trajectory < number_trajectories; trajectory++) {
-			delete[] trajectories[trajectory];
-		}
-
-		delete[] trajectories;
+		delete[] current_state;
 	}
 
 	template <typename TNum>
@@ -147,7 +128,7 @@ namespace Gillespy {
 				os << timeline[timestep] << ',';
 
 				for (int species = 0; species < model->number_species; species++) {
-					os << (double) trajectories[trajectory][timestep][species] << ',';
+					os << (double) current_state[species] << ',';
 				}
 			}
 		}

--- a/gillespy2/solvers/cpp/c_base/model.h
+++ b/gillespy2/solvers/cpp/c_base/model.h
@@ -145,8 +145,6 @@ namespace Gillespy
 		double end_time;
 		double *timeline;
 
-		PType *trajectories_1D;
-		PType ***trajectories;
 		PType *current_state;
 
 		Model<PType> *model;

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
@@ -71,6 +71,6 @@ int main(int argc, char* argv[])
 	Gillespy::TauHybrid::Event::use_events(events);
 
 	TauHybrid::TauHybridCSolver(&simulation, events, tau_tol);
-	simulation.output_results_buffer(std::cout);
+	simulation.output_buffer_final(std::cout);
 	return 0;
 }

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -94,8 +94,11 @@ namespace Gillespy
 				for (int spec_i = 0; spec_i < num_species; ++spec_i)
 				{
 					current_state[spec_i] = species[spec_i].initial_population;
+					simulation->current_state[spec_i] = current_state[spec_i];
 					current_populations[spec_i] = species[spec_i].initial_population;
 				}
+				simulation->reset_output_buffer(traj);
+				simulation->output_buffer_range(std::cout);
 
 				// Check for initial event triggers at t=0 (based on initial_value of trigger)
 				std::set<int> event_roots;
@@ -115,7 +118,6 @@ namespace Gillespy
 					spec->partition_mode = spec->user_mode == SimulationState::DYNAMIC
 										   ? SimulationState::DISCRETE
 										   : spec->user_mode;
-					simulation->trajectories[traj][0][spec_i] = current_state[spec_i];
 				}
 
 				// SIMULATION STEP LOOP
@@ -344,9 +346,10 @@ namespace Gillespy
 					{
 						for (int spec_i = 0; spec_i < num_species; ++spec_i)
 						{
-							simulation->trajectories[traj][save_idx][spec_i] = current_state[spec_i];
+							simulation->current_state[spec_i] = current_state[spec_i];
 						}
-						save_time = simulation->timeline[++save_idx];
+						simulation->output_buffer_range(std::cout, save_idx++);
+						save_time = simulation->timeline[save_idx];
 					}
 				}
 


### PR DESCRIPTION
Because the `TauHybridCSolver` used the deprecated `trajectories` array to store output results, only the first trajectory of the simulation is actually written to stdout. Fixed by updating the solver to use the up-to-date `output_buffer()` methods.

Closes #702 