### PR TITLE
Species State Rounding Fix

### DIFF
--- a/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
+++ b/gillespy2/solvers/cpp/c_base/Tau/tau.cpp
@@ -109,7 +109,7 @@ namespace Gillespy
 		return tau_args;
 	}
 
-	template<typename PType>
+	template<typename PType, typename SType>
 	double select(
 		Gillespy::Model<PType> &model,
 		TauArgs<PType> &tau_args,
@@ -117,7 +117,7 @@ namespace Gillespy
 		const double &current_time,
 		const double &save_time,
 		const std::vector<double> &propensity_values,
-		const std::vector<int> &current_state)
+		const std::vector<SType> &current_state)
 	{
 
 		bool critical = false;  // system-wide flag, true when any reaction is critical
@@ -261,14 +261,14 @@ namespace Gillespy
 
 	// Explicitly instantiate initialize/select functions for DISCRETE simulations
 	template TauArgs<double> initialize<double>(Model<double> &model, double tau_tol);
-	template double select<double>(
+	template double select<double, double>(
 		Model<double> &model,
 		TauArgs<double> &tau_args,
 		const double &tau_tol,
 		const double &current_time,
 		const double &save_time,
 		const std::vector<double> &propensity_values,
-		const std::vector<int> &current_state);
+		const std::vector<double> &current_state);
 
 	// Explicitly instantiate initialize/select functions for HYBRID simulations
 	template TauArgs<unsigned int> initialize<unsigned int>(Model<unsigned int> &model, double tau_tol);

--- a/gillespy2/solvers/cpp/c_base/Tau/tau.h
+++ b/gillespy2/solvers/cpp/c_base/Tau/tau.h
@@ -47,7 +47,7 @@ namespace Gillespy
     template<typename PType>
     TauArgs<PType> initialize(Model<PType> &model, double tau_tol);
 
-    template<typename PType>
+    template<typename PType, typename SType = int>
     double select(
         Model<PType> &model,
         TauArgs<PType> &tau_args,
@@ -55,19 +55,19 @@ namespace Gillespy
         const double &current_time,
         const double &save_time,
         const std::vector<double> &propensity_values,
-        const std::vector<int> &current_state);
+        const std::vector<SType> &current_state);
 
     // Continuous tau args is used by hybrid solver
     template struct TauArgs<double>;
     extern template TauArgs<double> initialize(Model<double> &model, double tau_tol);
-    extern template double select<double>(
+    extern template double select<double, double>(
         Model<double> &model,
         TauArgs<double> &tau_args,
         const double &tau_tol,
         const double &current_time,
         const double &save_time,
         const std::vector<double> &propensity_values,
-        const std::vector<int> &current_state);
+        const std::vector<double> &current_state);
 
     // Discrete tau args is used by tau leaping solver
     template struct TauArgs<unsigned int>;

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
@@ -242,8 +242,7 @@ namespace Gillespy
 
 		double DifferentialEquation::evaluate(
 				const double t,
-				double *ode_state,
-				int *ssa_state)
+				double *ode_state)
 		{
 			double sum = 0.0;
 
@@ -254,7 +253,7 @@ namespace Gillespy
 
 			for (auto &formula : formulas)
 			{
-				sum += formula(ode_state, ssa_state);
+				sum += formula(ode_state);
 			}
 
 			return sum;
@@ -293,29 +292,9 @@ namespace Gillespy
 					auto &formula_set = spec.diff_equation.formulas;
 					int spec_diff = rxn.base_reaction->species_change[spec_i];
 
-					switch (spec.partition_mode)
-					{
-					case SimulationState::CONTINUOUS:
-						formula_set.push_back([rxn_i, spec_diff](
-								double *ode_state,
-								int *ssa_state)
-											  {
-												  return spec_diff * Reaction::propensity(rxn_i, ode_state);
-											  });
-						break;
-
-					case SimulationState::DISCRETE:
-						formula_set.push_back([rxn_i, spec_diff](
-								double *ode_state,
-								int *ssa_state)
-											  {
-												  return spec_diff * Reaction::propensity(rxn_i, ssa_state);
-											  });
-						break;
-
-					default:
-						break;
-					}
+					formula_set.push_back([rxn_i, spec_diff](double *state) {
+						return spec_diff * Reaction::propensity(rxn_i, state);
+					});
 				}
 			}
 		}

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
@@ -177,10 +177,10 @@ namespace Gillespy
 		struct DifferentialEquation
 		{
 		public:
-			std::vector<std::function<double(double *, int *)>> formulas;
+			std::vector<std::function<double(double *)>> formulas;
 			std::vector<std::function<double(double, double *, double *, const double *)>> rate_rules;
 
-			double evaluate(double t, double *ode_state, int *ssa_state);
+			double evaluate(double t, double *ode_state);
 		};
 
 		enum SimulationState : unsigned int

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
@@ -227,10 +227,62 @@ namespace Gillespy
 
 		struct HybridReaction
 		{
-			Reaction *base_reaction;
 			SimulationState mode;
 
+			inline double propensity(double *state) const
+			{
+				return propensity(state, Reaction::s_variables.get(), Reaction::s_constants.get());
+			}
+
+			inline double propensity(double *state, double *parameters, const double *constants) const
+			{
+				switch (mode)
+				{
+				case SimulationState::CONTINUOUS:
+					return ode_propensity(state, parameters, constants);
+				case SimulationState::DISCRETE:
+				default:
+					return ssa_propensity(state, parameters, constants);
+				}
+			}
+
+			inline double ode_propensity(double *state) const
+			{
+				return ode_propensity(state, Reaction::s_variables.get(), Reaction::s_constants.get());
+			}
+
+			inline double ode_propensity(double *state, double *parameters, const double *constants) const
+			{
+				return map_ode_propensity(m_id, state, parameters, constants);
+			}
+
+			inline double ssa_propensity(double *state) const
+			{
+				return ssa_propensity(state, Reaction::s_variables.get(), Reaction::s_constants.get());
+			}
+
+			inline double ssa_propensity(double *state, double *parameters, const double *constants) const
+			{
+				return map_ssa_propensity(m_id, state, parameters, constants);
+			}
+
+			inline void set_base_reaction(Reaction *reaction)
+			{
+				m_base_reaction = reaction;
+				m_id = reaction->id;
+			}
+
+			inline Reaction *get_base_reaction() const
+			{
+				return m_base_reaction;
+			}
+
 			HybridReaction();
+			explicit HybridReaction(Reaction *base_reaction);
+
+		private:
+			Reaction *m_base_reaction;
+			ReactionId m_id;
 		};
 
 		struct HybridSimulation : Simulation<double>

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -88,13 +88,11 @@ namespace Gillespy
 				// TODO: change back double -> hybrid_state, once we figure out how that works
 				EventList event_list;
 				std::vector<double> current_state(num_species);
-				std::vector<int> current_populations(num_species);
 
 				// Initialize the species population for the trajectory.
 				for (int spec_i = 0; spec_i < num_species; ++spec_i)
 				{
 					current_state[spec_i] = species[spec_i].initial_population;
-					current_populations[spec_i] = species[spec_i].initial_population;
 				}
 
 				// Check for initial event triggers at t=0 (based on initial_value of trigger)
@@ -142,19 +140,7 @@ namespace Gillespy
 					for (unsigned int rxn_i = 0; rxn_i < num_reactions; ++rxn_i)
 					{
 						HybridReaction &rxn = simulation->reaction_state[rxn_i];
-						double propensity = 0.0;
-						switch (rxn.mode)
-						{
-						case SimulationState::CONTINUOUS:
-							propensity = Reaction::propensity(rxn_i, current_state.data());
-							break;
-						case SimulationState::DISCRETE:
-							propensity = Reaction::propensity(rxn_i, current_populations.data());
-							break;
-						default:
-							break;
-						}
-						sol.data.propensities[rxn_i] = propensity;
+						sol.data.propensities[rxn_i] = rxn.propensity(current_state.data());
 					}
 
 					// Expected tau step is determined.
@@ -301,7 +287,6 @@ namespace Gillespy
 									current_state[p_i] += population_changes[p_i];
 									result.concentrations[p_i] = current_state[p_i];
 								}
-								current_populations[p_i] = (int) current_state[p_i];
 							}
 						}
 					} while (invalid_state);

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -158,14 +158,14 @@ namespace Gillespy
 					}
 
 					// Expected tau step is determined.
-					tau_step = select(
+					tau_step = select<double, double>(
 							model,
 							tau_args,
 							tau_tol,
 							simulation->current_time,
 							save_time,
 							sol.data.propensities,
-							current_populations
+							current_state
 					);
 					partition_species(
 							simulation->reaction_state,

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
@@ -58,9 +58,6 @@ namespace Gillespy
 		// In `rootfn`, this means that gout[i] is the "output" of reaction active_reaction_ids[i].
 		// This is used to map the internal reaction number to the actual reaction id.
 		std::vector<unsigned int> active_reaction_ids;
-
-		std::vector<double> concentrations;
-		std::vector<int> populations;
 		std::vector<double> propensities;
 
 		IntegratorData(HybridSimulation *simulation);

--- a/gillespy2/solvers/cpp/c_base/template/template.cpp
+++ b/gillespy2/solvers/cpp/c_base/template/template.cpp
@@ -88,6 +88,84 @@ namespace Gillespy
 		return constants;
 	}
 
+	double map_ssa_propensity(unsigned int reaction_id, int *S, double *P, const double *C)
+	{
+		switch (reaction_id)
+		{
+			#define PROPENSITY(id, func) case(id): return(func);
+			GPY_PROPENSITIES
+			#undef PROPENSITY
+
+		default:
+			return -1.0;
+		}
+	}
+
+	double map_ssa_propensity(unsigned int reaction_id, unsigned int *S, double *P, const double *C)
+	{
+		switch (reaction_id)
+		{
+			#define PROPENSITY(id, func) case(id): return(func);
+			GPY_PROPENSITIES
+			#undef PROPENSITY
+
+		default:
+			return -1.0;
+		}
+	}
+
+	double map_ssa_propensity(unsigned int reaction_id, double *S, double *P, const double *C)
+	{
+		switch (reaction_id)
+		{
+			#define PROPENSITY(id, func) case(id): return(func);
+			GPY_PROPENSITIES
+			#undef PROPENSITY
+
+		default:
+			return -1.0;
+		}
+	}
+
+	double map_ode_propensity(unsigned int reaction_id, int *S, double *P, const double *C)
+	{
+		switch (reaction_id)
+		{
+			#define PROPENSITY(id, func) case(id): return(func);
+			GPY_ODE_PROPENSITIES
+			#undef PROPENSITY
+
+		default:
+			return -1.0;
+		}
+	}
+
+	double map_ode_propensity(unsigned int reaction_id, unsigned int *S, double *P, const double *C)
+	{
+		switch (reaction_id)
+		{
+			#define PROPENSITY(id, func) case(id): return(func);
+			GPY_ODE_PROPENSITIES
+			#undef PROPENSITY
+
+		default:
+			return -1.0;
+		}
+	}
+
+	double map_ode_propensity(unsigned int reaction_id, double *S, double *P, const double *C)
+	{
+		switch (reaction_id)
+		{
+			#define PROPENSITY(id, func) case(id): return(func);
+			GPY_ODE_PROPENSITIES
+			#undef PROPENSITY
+
+		default:
+			return -1.0;
+		}
+	}
+
 	double map_propensity(unsigned int reaction_id, unsigned int *S, double *P, const double *C)
 	{
 		switch (reaction_id)

--- a/gillespy2/solvers/cpp/c_base/template/template.h
+++ b/gillespy2/solvers/cpp/c_base/template/template.h
@@ -38,6 +38,13 @@ namespace Gillespy
 	double map_propensity(unsigned int reaction_id, unsigned int *S, double *parameters, const double *constants);
 	double map_propensity(unsigned int reaction_id, double *S, double *parameters, const double *constants);
 
+	double map_ssa_propensity(unsigned int reaction_id, int *state, double *parameters, const double *constants);
+	double map_ssa_propensity(unsigned int reaction_id, unsigned int *state, double *parameters, const double *constants);
+	double map_ssa_propensity(unsigned int reaction_id, double *state, double *parameters, const double *constants);
+	double map_ode_propensity(unsigned int reaction_id, int *state, double *parameters, const double *constants);
+	double map_ode_propensity(unsigned int reaction_id, unsigned int *state, double *parameters, const double *constants);
+	double map_ode_propensity(unsigned int reaction_id, double *state, double *parameters, const double *constants);
+
 	template <typename T>
 	void add_reactions(Model<T> &model);
 


### PR DESCRIPTION
Fixes the issue where numerical errors are introduced with continuous values when being evaluated for stochastic reactions. It's fixed by making the simulation's `current_state` array be exclusively `double`, instead of using a `double` array for deterministic reactions and a separate `int` array for stochastic ones.

# Changes
- All instances of `current_populations` vector in C++ solver are removed
  - Any areas that were previously dependent on `current_populations` (`int` vector) now use `current_state` instead (`double` vector)
- `map_ode_propensity` and `map_ssa_propensity` are added to the template file, which allows the hybrid solver to explicitly specify which propensity to use
  - In contrast, previously the decision of "which propensity to use" was based on a function overload of `map_propensity`, where the decision was made based on the type (`double` or `int`) of the state vector
- Integrator RHS always uses the integrator state in propensity functions, regardless of reaction type
- Added propensity methods to `HybridReaction` class, to reduce code duplication
- Added Tau select overload that accepts `double` as state vector
- Added unit test to check for rounding errors in continuous species

# Fixes
- Stochastic reactions no longer truncate continuous species values, which was preventing certain reactions from firing