### PR TITLE
FIX: C++ Event trigger evaluation

### DIFF
--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
@@ -505,14 +505,11 @@ namespace Gillespy
 			// Step 1: Identify any fired event triggers.
 			for (auto &event : m_events)
 			{
-				bool trigger = event.trigger(t, event_state);
-				if (m_trigger_state.at(event.get_event_id()) != trigger)
+				if (m_trigger_state.at(event.get_event_id()) != event.trigger(t, event_state))
 				{
 					double delay = event.delay(t, event_state);
 					EventExecution execution = event.get_execution(t + delay, event_state, output_size);
 
-					// Update trigger state to prevent repeated firings.
-					m_trigger_state.find(event.get_event_id())->second = trigger;
 					if (delay <= 0)
 					{
 						// Immediately put EventExecution on "triggered" pile
@@ -588,6 +585,13 @@ namespace Gillespy
 				event.execute(t, event_state);
 				trigger_queue.pop();
 				m_trigger_pool.erase(event.get_event_id());
+			}
+
+			// Step 5: Update trigger states based on the new simulation state.
+			// This is to account for events that re-assign values that the event triggers depend on.
+			for (auto &event : m_events)
+			{
+				m_trigger_state.at(event.get_event_id()) = event.trigger(t, event_state);
 			}
 
 			return has_active_events();


### PR DESCRIPTION
Fixes an issue where Events that reassign a value that is also included in the trigger expression causes events to be fired twice. This occurred because trigger state was not being evaluated after Event Assignments are executed, resulting in a "second transition" being incorrectly detected.

To replicate, execute the code found in the notebook in issue #715 

Closes #715 