### PR TITLE
FIX: Hybrid C++ integrator initialization errors

### DIFF
--- a/gillespy2/solvers/cpp/build/template_gen.py
+++ b/gillespy2/solvers/cpp/build/template_gen.py
@@ -43,6 +43,7 @@ class SanitizedModel:
     # as well as functions in Python that have a different name in C++.
     function_map = {
         "abs": "abs",
+        "round": "round",
     }
 
     def __init__(self, model: Model, variable=False):

--- a/gillespy2/solvers/cpp/c_base/arg_parser.cpp
+++ b/gillespy2/solvers/cpp/c_base/arg_parser.cpp
@@ -25,6 +25,11 @@
 
 char ArgParser::match_arg(std::string &token)
 {
+	if (!token.compare("--verbose"))
+	{
+		return 'v';
+	}
+
 	if (!token.compare("--timesteps"))
 	{
 		return 't';
@@ -152,6 +157,10 @@ ArgParser::ArgParser(int argc, char *argv[])
 
 			case 'V':
 				arg_stream >> output_interval;
+				break;
+
+			case 'v':
+				verbose = true;
 				break;
 
 			default:

--- a/gillespy2/solvers/cpp/c_base/arg_parser.h
+++ b/gillespy2/solvers/cpp/c_base/arg_parser.h
@@ -47,6 +47,8 @@ public:
     double switch_tol = 0.0;
     double tau_tol = 0.03;
 
+    bool verbose = false;
+
     ArgParser(int argc, char *argv[]);
     ~ArgParser();
 };

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.cpp
@@ -200,27 +200,17 @@ namespace Gillespy
 			return m_execution_time > rhs.m_execution_time;
 		}
 
-
-		HybridReaction::HybridReaction()
-				: mode(SimulationState::DISCRETE),
-				  m_base_reaction(nullptr),
-				  m_id(-1)
-		{
-			// Empty constructor body
-		}
-
 		HybridReaction::HybridReaction(Reaction *base_reaction)
-			: HybridReaction()
+			: mode(SimulationState::DISCRETE),
+			  m_base_reaction(base_reaction)
 		{
-			base_reaction = base_reaction;
 			m_id = base_reaction->id;
 		}
 
-		HybridSpecies::HybridSpecies()
+		HybridSpecies::HybridSpecies(Species<double> *base_species)
 				: user_mode(SimulationState::DYNAMIC),
 				  partition_mode(SimulationState::DISCRETE),
-				  switch_tol(0.03),
-				  switch_min(0)
+				  m_base_species(base_species)
 		{
 			// Empty constructor body
 		}
@@ -232,18 +222,16 @@ namespace Gillespy
 		}
 
 		HybridSimulation::HybridSimulation(const Model<double> &model)
-				: Simulation<double>(),
-				  species_state(model.number_species),
-				  reaction_state(model.number_reactions)
+				: Simulation<double>()
 		{
 			for (int spec_i = 0; spec_i < model.number_species; ++spec_i)
 			{
-				species_state[spec_i].base_species = &model.species[spec_i];
+				species_state.emplace_back(HybridSpecies(model.species.get() + spec_i));
 			}
 
 			for (int rxn_i = 0; rxn_i < model.number_reactions; ++rxn_i)
 			{
-				reaction_state[rxn_i].set_base_reaction(&model.reactions[rxn_i]);
+				reaction_state.emplace_back(HybridReaction(model.reactions.get() + rxn_i));
 			}
 		}
 

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
@@ -192,8 +192,6 @@ namespace Gillespy
 
 		struct HybridSpecies
 		{
-			Species<double> *base_species;
-
 			// allows the user to specify if a species' population should definitely be modeled continuously or
 			// discretely
 			// CONTINUOUS or DISCRETE
@@ -222,7 +220,11 @@ namespace Gillespy
 			// If `boundary_condition` is true, then reactants are not consumed, and products are not produced.
 			bool boundary_condition = false;
 
-			HybridSpecies();
+			HybridSpecies() = delete;
+			explicit HybridSpecies(Species<double> *species);
+
+		private:
+			Species<double> *m_base_species;
 		};
 
 		struct HybridReaction
@@ -277,7 +279,7 @@ namespace Gillespy
 				return m_base_reaction;
 			}
 
-			HybridReaction();
+			HybridReaction() = delete;
 			explicit HybridReaction(Reaction *base_reaction);
 
 		private:

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
@@ -70,7 +70,7 @@ int main(int argc, char* argv[])
 	std::vector<Gillespy::TauHybrid::Event> events;
 	Gillespy::TauHybrid::Event::use_events(events);
 
-	TauHybrid::TauHybridCSolver(&simulation, events, tau_tol);
+	TauHybrid::TauHybridCSolver(&simulation, events, tau_tol, parser.verbose);
 	simulation.output_buffer_final(std::cout);
 	return 0;
 }

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -251,10 +251,6 @@ namespace Gillespy
 										{
 											population_changes[spec_i] +=
 													model.reactions[rxn_i].species_change[spec_i];
-											if (current_state[spec_i] + population_changes[spec_i] < 0)
-											{
-												invalid_state = true;
-											}
 										}
 
 										rxn_state += log(urn.next());
@@ -266,6 +262,16 @@ namespace Gillespy
 								default:
 									break;
 								}
+							}
+						}
+
+						// Explicitly check for invalid population state, now that changes have been tallied.
+						for (int spec_i = 0; spec_i < num_species; ++spec_i)
+						{
+							if (current_state[spec_i] + population_changes[spec_i] < 0)
+							{
+								invalid_state = true;
+								break;
 							}
 						}
 

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -32,6 +32,9 @@
 #include "integrator.h"
 #include "tau.h"
 
+static void silent_error_handler(int error_code, const char *module, const char *function_name,
+						  char *message, void *eh_data);
+
 namespace Gillespy
 {
 	static volatile bool interrupted = false;
@@ -42,7 +45,7 @@ namespace Gillespy
 
 	namespace TauHybrid
 	{
-		void TauHybridCSolver(HybridSimulation *simulation, std::vector<Event> &events, const double tau_tol)
+		void TauHybridCSolver(HybridSimulation *simulation, std::vector<Event> &events, const double tau_tol, bool verbose)
 		{
 			if (simulation == NULL)
 			{
@@ -71,6 +74,10 @@ namespace Gillespy
 				y = y0;
 			}
 			Integrator sol(simulation, y, GPY_HYBRID_RELTOL, GPY_HYBRID_ABSTOL);
+			if (!verbose)
+			{
+				sol.set_error_handler(silent_error_handler);
+			}
 
 			// Tau selector initialization. Used to select a valid tau step.
 			TauArgs<double> tau_args = initialize(model, tau_tol);
@@ -361,4 +368,10 @@ namespace Gillespy
 			}
 		}
 	}
+}
+
+void silent_error_handler(int error_code, const char *module, const char *function_name,
+						  char *message, void *eh_data)
+{
+	// Do nothing
 }

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.h
@@ -25,6 +25,6 @@ namespace Gillespy
 {
 	namespace TauHybrid
 	{
-    	void TauHybridCSolver(HybridSimulation* simulation, std::vector<Event> &events, double tau_tol);
+    	void TauHybridCSolver(HybridSimulation* simulation, std::vector<Event> &events, double tau_tol, bool verbose);
 	}
 }

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/hybrid_template.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/hybrid_template.cpp
@@ -18,10 +18,13 @@
 
 #include "hybrid_template.h"
 #include "template_params.h"
+#include <cmath>
 
 // , cannot be overridden, so we can't use it as a delimiter
 // Use a separate macro to represent a delimiter
 #define AND ,
+
+using namespace std;
 
 namespace Gillespy
 {

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
@@ -212,6 +212,11 @@ bool Integrator::disable_root_finder()
 	return validate(this, CVodeRootInit(cvode_mem, 0, NULL));
 }
 
+void Integrator::set_error_handler(CVErrHandlerFn error_handler)
+{
+	validate(this, CVodeSetErrHandlerFn(cvode_mem, error_handler, nullptr));
+}
+
 URNGenerator::URNGenerator(unsigned long long seed)
 	: uniform(0, 1),
 	  rng(seed)

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
@@ -156,7 +156,7 @@ IntegrationResults Integrator::integrate(double *t, std::set<int> &event_roots, 
 
 		for (; root_id < num_rxn_roots; ++root_id)
 		{
-			if (root_results[root_id] != 0)
+			if (root_results[root_id] < 0)
 			{
 				reaction_roots.insert(data.active_reaction_ids[root_id]);
 			}

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
@@ -151,6 +151,8 @@ namespace Gillespy
 		/// and the underlying SBML event data and reaction data are removed.
 		bool disable_root_finder();
 
+		void set_error_handler(CVErrHandlerFn error_handler);
+
 		IntegrationResults integrate(double *t);
 		IntegrationResults integrate(double *t, std::set<int> &event_roots, std::set<unsigned int> &reaction_roots);
 		IntegratorData data;

--- a/gillespy2/solvers/cpp/c_base/template/template.cpp
+++ b/gillespy2/solvers/cpp/c_base/template/template.cpp
@@ -237,6 +237,7 @@ namespace Gillespy
 
 		for (rxn_i = 0; rxn_i < GPY_NUM_REACTIONS; ++rxn_i)
 		{
+			model.reactions[rxn_i].id = rxn_i;
 			for (spec_i = 0; spec_i < GPY_NUM_SPECIES; ++spec_i)
 			{
 				model.reactions[rxn_i].species_change[spec_i] = reactions[rxn_i][spec_i];

--- a/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
+++ b/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
@@ -219,6 +219,8 @@ class TauHybridCSolver(GillesPySolver, CSolver):
             display_args = None
 
         args = self._make_args(args)
+        if debug:
+            args.append("--verbose")
         decoder = IterativeSimDecoder.create_default(number_of_trajectories, number_timesteps, len(self.model.listOfSpecies))
 
         sim_exec = self._build(self.model, self.target, self.variable, False)


### PR DESCRIPTION
This fixes some issues from the previous PRs, in particular one caused by a discrepancy between PRs in how hybrid solver data structures are initialized.

# Fixes
- All hybrid data structures are now explicitly initialized; fixes undefined behavior in new propensity functions.
- Invalid population state is checked *after* reactions are evaluated; fixes an issue where the population state can go negative on event-search intervals.
- Added a `--verbose` flag to the Tau Hybrid C++ solver, silencing all CVODE errors by default. You can re-enable them by setting `debug=True` when running the solver.
- Added support for math functions, `round()` in `Event` expressions