### PR TITLE
FIX: `ImportError` raised in `Results` object

### DIFF
--- a/gillespy2/core/results.py
+++ b/gillespy2/core/results.py
@@ -357,7 +357,7 @@ class Results(UserList, Jsonify):
         """
 
         import matplotlib.pyplot as plt
-        from collections import Iterable
+        from collections.abc import Iterable
         trajectory_list = []
         if isinstance(index, Iterable):
             for i in index:
@@ -468,7 +468,7 @@ class Results(UserList, Jsonify):
 
         init_notebook_mode(connected=True)
 
-        from collections import Iterable
+        from collections.abc import Iterable
         trajectory_list = []
         if isinstance(index, Iterable):
             for i in index:


### PR DESCRIPTION
Replaces deprecated `Iterable` import in `Results.py`, allowing plot methods to work in 3.10+.

# Fixes
- `ImportError` no longer raised in `Results#plot`
- `ImportError` no longer raised in `Results#plotplotly`

Closes #757 