### PR TITLE
Updated `run-full-tests` GH action.

### DIFF
--- a/.github/workflows/run-full-tests.yml
+++ b/.github/workflows/run-full-tests.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        python-versions: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-versions: [ '3.7', '3.8', '3.9', '3.10' ]
 
     steps:
     - name: Initialize environment


### PR DESCRIPTION
This is a short-n-simple PR which replaces the (now EOL) python 3.6 target with 3.10 in the `run-full-tests` Github action. Ideally this will prevent issues like #757 from making it to package deployment.