### PR TITLE
Fixed double output from global logger.

### DIFF
--- a/gillespy2/core/__init__.py
+++ b/gillespy2/core/__init__.py
@@ -32,12 +32,18 @@ from .sortableobject import *
 from .species import *
 from gillespy2.__version__ import __version__
 
-_formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-_handler = logging.StreamHandler()
-_handler.setFormatter(_formatter)
 version = __version__
-log = logging.getLogger()
+
+log = logging.getLogger("root")
 log.setLevel(logging.WARN)
-log.addHandler(_handler)
+log.propagate = False
+
+if not log.handlers:
+    _formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+
+    _handler = logging.StreamHandler()
+    _handler.setFormatter(_formatter)
+
+    log.addHandler(_handler)
 
 __all__ = [s for s in dir() if not s.startswith('_')]

--- a/gillespy2/core/__init__.py
+++ b/gillespy2/core/__init__.py
@@ -34,7 +34,7 @@ from gillespy2.__version__ import __version__
 
 version = __version__
 
-log = logging.getLogger("root")
+log = logging.getLogger("GillesPy2")
 log.setLevel(logging.WARN)
 log.propagate = False
 

--- a/test/test_all_solvers.py
+++ b/test/test_all_solvers.py
@@ -144,14 +144,14 @@ class TestAllSolvers(unittest.TestCase):
 
     def test_extraneous_args(self):
         for solver in self.solvers:
-            with self.subTest(solver=solver.name), self.assertLogs('root', level='WARN'):
+            with self.subTest(solver=solver.name), self.assertLogs('GillesPy2', level='WARN'):
                 model = Example()
                 solver = solver(model=model)
                 model.run(solver=solver, nonsense='ABC')
 
     def test_timeout(self):
         for solver in self.solvers:
-            with self.subTest(solver=solver.name), self.assertLogs('root', level='WARN'):
+            with self.subTest(solver=solver.name), self.assertLogs('GillesPy2', level='WARN'):
                 model = Oregonator()
                 model.timespan(np.linspace(0, 1000000, 1001))
                 solver = solver(model=model)

--- a/test/test_all_solvers.py
+++ b/test/test_all_solvers.py
@@ -144,14 +144,14 @@ class TestAllSolvers(unittest.TestCase):
 
     def test_extraneous_args(self):
         for solver in self.solvers:
-            with self.subTest(solver=solver.name), self.assertLogs(level='WARN'):
+            with self.subTest(solver=solver.name), self.assertLogs('root', level='WARN'):
                 model = Example()
                 solver = solver(model=model)
                 model.run(solver=solver, nonsense='ABC')
 
     def test_timeout(self):
         for solver in self.solvers:
-            with self.subTest(solver=solver.name), self.assertLogs(level='WARN'):
+            with self.subTest(solver=solver.name), self.assertLogs('root', level='WARN'):
                 model = Oregonator()
                 model.timespan(np.linspace(0, 1000000, 1001))
                 solver = solver(model=model)

--- a/test/test_hybrid_solver.py
+++ b/test/test_hybrid_solver.py
@@ -191,7 +191,7 @@ class TestBasicTauHybridSolver(unittest.TestCase):
         model = Example()
         species1 = gillespy2.Species('test_species1', initial_value=1, mode='dynamic')
         model.add_species(species1)
-        with self.assertLogs('root', level='WARN'):
+        with self.assertLogs('GillesPy2', level='WARN'):
             solver = TauHybridSolver(model=model)
             results = model.run(solver=solver, timeout=1)
 

--- a/test/test_hybrid_solver.py
+++ b/test/test_hybrid_solver.py
@@ -191,7 +191,7 @@ class TestBasicTauHybridSolver(unittest.TestCase):
         model = Example()
         species1 = gillespy2.Species('test_species1', initial_value=1, mode='dynamic')
         model.add_species(species1)
-        with self.assertLogs(level='WARN'):
+        with self.assertLogs('root', level='WARN'):
             solver = TauHybridSolver(model=model)
             results = model.run(solver=solver, timeout=1)
 

--- a/test/test_ode_solver.py
+++ b/test/test_ode_solver.py
@@ -36,7 +36,7 @@ class TestBasicODESolver(unittest.TestCase):
             for label in [True, False]:
                 with self.subTest(number_of_trajectories=i, show_labels=label):
                     if i > 1:
-                        with self.assertLogs('root', level='WARN'):
+                        with self.assertLogs('GillesPy2', level='WARN'):
                             results = model.run(solver=solver, show_labels=label, number_of_trajectories=i)
                         self.assertEqual(len(results), i)
                     else:

--- a/test/test_ode_solver.py
+++ b/test/test_ode_solver.py
@@ -36,7 +36,7 @@ class TestBasicODESolver(unittest.TestCase):
             for label in [True, False]:
                 with self.subTest(number_of_trajectories=i, show_labels=label):
                     if i > 1:
-                        with self.assertLogs(level='WARN'):
+                        with self.assertLogs('root', level='WARN'):
                             results = model.run(solver=solver, show_labels=label, number_of_trajectories=i)
                         self.assertEqual(len(results), i)
                     else:


### PR DESCRIPTION
A quick fix which resolves #761 via the following changes: 

- Added branch to ensure log handlers can't be installed multiple times. This is relevant in (rare) cases when `gillespy2/core/__init__.py` is evaluated more than once.
- Set global logger name to `root` and set `logger.propagate` to `False`. This is the change which ensures that log writes only occur once.