### PR TITLE
HOTFIX: zero output bug with `variable=True`

### DIFF
--- a/gillespy2/solvers/cpp/c_base/arg_parser.cpp
+++ b/gillespy2/solvers/cpp/c_base/arg_parser.cpp
@@ -86,8 +86,6 @@ char ArgParser::match_arg(std::string &token)
 	}
 }
 
-static std::stringstream &fill_stream(std::stringstream &stream, char *argv[]);
-
 ArgParser::ArgParser(int argc, char *argv[])
 {
 	std::stringstream arg_stream;
@@ -138,11 +136,13 @@ ArgParser::ArgParser(int argc, char *argv[])
 				break;
 
 			case 'I':
-				Gillespy::map_variable_populations(fill_stream(arg_stream, &argv[i + 1]));
+				arg_stream = std::stringstream(argv[i + 1]);
+				Gillespy::map_variable_populations(arg_stream);
 				break;
 
 			case 'p':
-				Gillespy::map_variable_parameters(fill_stream(arg_stream, &argv[i + 1]));
+				arg_stream = std::stringstream(argv[i + 1]);
+				Gillespy::map_variable_parameters(arg_stream);
 				break;
 
 			case 'T':
@@ -172,13 +172,6 @@ ArgParser::ArgParser(int argc, char *argv[])
 	increment = increment > 0 ? increment : end / (timesteps - 1);
 	// Output interval must lie within the range (0, num_timesteps]
 	output_interval = std::max(1, std::min(timesteps, output_interval));
-}
-
-std::stringstream &fill_stream(std::stringstream &stream, char *argv[])
-{
-	for (char *arg = argv[0]; arg[0] != '-'; ++arg)
-		stream << arg;
-	return stream;
 }
 
 ArgParser::~ArgParser()


### PR DESCRIPTION
A change committed to develop caused an incompatibility with a bugfix for the C++ argument parser. This caused output to be "zeroed out" when `variable=True` is set, due to a serialization mismatch in the argument parser.

The fix was to modify the argument parser to handle this serialization mismatch.

# Fixes
- Removes regression bug where output is all zeroes when running `variable=True` with any C++ solver