### PR TITLE
HOTFIX: relax overly strict integration guard in `TauHybridCSolver`

### DIFF
--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -194,7 +194,7 @@ namespace Gillespy
 
 					// This is a temporary fix. Ideally, invalid state should allow for integrator options change.
 					// For now, a "guard" is put in place to prevent potentially infinite loops from occurring.
-					unsigned int integration_guard = 3;
+					unsigned int integration_guard = 1000;
 
 					do
 					{


### PR DESCRIPTION
Unit tests and simulations using `TauHybridCSolver` tended to fail more frequently than expected on low-population models. This appears to be due to the integration guard being too strict; it was, at some point, reduced from its original value of 1000 to 3.

The fix is to restore it to its original value of 1000.

# Fixes
- Fixes bug causing moderate failure rates on some models with `TauHybridCSolver`

Closes #772