### PR TITLE
Integrator options support + validation

### DIFF
--- a/gillespy2/core/gillespySolver.py
+++ b/gillespy2/core/gillespySolver.py
@@ -112,6 +112,10 @@ class GillesPySolver:
         return set()
 
     @classmethod
+    def get_supported_integrator_options(cls) -> "Set[str]":
+        return set()
+
+    @classmethod
     def validate_model(cls, sol_model, model):
         if model is not None:
             model.resolve_parameters()
@@ -129,3 +133,8 @@ class GillesPySolver:
             raise ModelError(f"Could not run Model, "
                              f"SBML Features not supported by {cls.name}: " +
                              ", ".join(unsupported_features))
+
+    @classmethod
+    def validate_integrator_options(cls, options: "dict[str, float]") -> "dict[str, float]":
+        return { option: value for option, value in options.items() if option in cls.get_supported_integrator_options() }
+

--- a/gillespy2/solvers/cpp/c_base/arg_parser.cpp
+++ b/gillespy2/solvers/cpp/c_base/arg_parser.cpp
@@ -80,6 +80,21 @@ char ArgParser::match_arg(std::string &token)
 		return 'V';
 	}
 
+	if (!token.compare("--rtol"))
+	{
+		return 'R';
+	}
+
+	if (!token.compare("--atol"))
+	{
+		return 'A';
+	}
+
+	if (!token.compare("--max_step"))
+	{
+		return 'M';
+	}
+
 	else
 	{
 		return 0;
@@ -159,6 +174,18 @@ ArgParser::ArgParser(int argc, char *argv[])
 
 			case 'v':
 				verbose = true;
+				break;
+
+			case 'R':
+				std::stringstream(argv[i + 1]) >> rtol;
+				break;
+
+			case 'A':
+				std::stringstream(argv[i + 1]) >> atol;
+				break;
+
+			case 'M':
+				std::stringstream(argv[i + 1]) >> max_step;
 				break;
 
 			default:

--- a/gillespy2/solvers/cpp/c_base/arg_parser.h
+++ b/gillespy2/solvers/cpp/c_base/arg_parser.h
@@ -46,7 +46,7 @@ public:
     double increment = 0.0;
     double switch_tol = 0.0;
     double tau_tol = 0.03;
-    double max_step = 0.25;
+    double max_step = 0.0; // max_step of 0.0 is the default; CVODE interprets this as "infinity," aka "no limit to step size"
     double rtol = 1e-9;
     double atol = 1e-12;
 

--- a/gillespy2/solvers/cpp/c_base/arg_parser.h
+++ b/gillespy2/solvers/cpp/c_base/arg_parser.h
@@ -46,6 +46,9 @@ public:
     double increment = 0.0;
     double switch_tol = 0.0;
     double tau_tol = 0.03;
+    double max_step = 0.25;
+    double rtol = 1e-9;
+    double atol = 1e-12;
 
     bool verbose = false;
 

--- a/gillespy2/solvers/cpp/c_base/model.h
+++ b/gillespy2/solvers/cpp/c_base/model.h
@@ -222,6 +222,16 @@ namespace Gillespy
 		uint8_t m_status = 0;
 	};
 
+	/// \name SolverConfiguration
+	/// \brief Container struct for ODE-specific configuration data.
+	/// Used in ODE and Hybrid solvers to configure SUNDIALS solvers.
+	struct SolverConfiguration
+	{
+		double rel_tol;
+		double abs_tol;
+		double max_step;
+	};
+
 	enum class LogLevel
 	{
 		INFO   = 0,

--- a/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESimulation.cpp
@@ -74,8 +74,15 @@ int main(int argc, char *argv[]) {
 
 	init_simulation(&model, simulation);
 
+	// Configure solver based on command-line arguments (or defaults)
+	SolverConfiguration config = {
+		parser.rtol,
+		parser.atol,
+		parser.max_step,
+	};
+
 	simulation.reset_output_buffer(0);
-	ODESolver(&simulation, increment);
+	ODESolver(&simulation, increment, config);
 	simulation.output_buffer_final(std::cout);
 
 	return simulation.get_status();

--- a/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.cpp
@@ -87,6 +87,12 @@ namespace Gillespy
 		// Initialize the ODE solver and set tolerances.
 		flag = CVodeInit(cvode_mem, f, t0, y0);
 		flag = CVodeSStolerances(cvode_mem, config.rel_tol, config.abs_tol);
+		switch (CVodeSetMaxStep(cvode_mem, config.max_step))
+		{
+			case CV_ILL_INPUT:
+				std::cerr << "Bad step size: " << config.max_step << std::endl;
+				break;
+		}
 
 		// Initialize and select the linear solver module.
 		// SUNSPMR: Iterative Solver (compatible with serial, threaded, parallel, and user suppoed NVector).

--- a/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.cpp
@@ -49,7 +49,7 @@ namespace Gillespy
         return (fabs(A - B) < FLT_EPSILON);
     }
 
-	void ODESolver(Simulation<double> *simulation, double increment)
+	void ODESolver(Simulation<double> *simulation, double increment, SolverConfiguration config)
 	{
 		GPY_INTERRUPT_INSTALL_HANDLER(signal_handler);
 
@@ -63,10 +63,6 @@ namespace Gillespy
 		// Allocate memory for data passed into RHS.
 		UserData *data = new UserData();
 		data->my_sim = simulation;
-
-		// Init the absolute and real tolerances of the system.
-		realtype abstol = 1e-5;
-		realtype reltol = 1e-5;
 
 		// Init the initial conditions.
 		sunindextype N = (simulation->model)->number_species;
@@ -90,7 +86,7 @@ namespace Gillespy
 
 		// Initialize the ODE solver and set tolerances.
 		flag = CVodeInit(cvode_mem, f, t0, y0);
-		flag = CVodeSStolerances(cvode_mem, reltol, abstol);
+		flag = CVodeSStolerances(cvode_mem, config.rel_tol, config.abs_tol);
 
 		// Initialize and select the linear solver module.
 		// SUNSPMR: Iterative Solver (compatible with serial, threaded, parallel, and user suppoed NVector).

--- a/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.h
+++ b/gillespy2/solvers/cpp/c_base/ode_cpp_solver/ODESolver.h
@@ -21,5 +21,5 @@
 
 namespace Gillespy
 {
-	void ODESolver(Gillespy::Simulation<double> *simulation, double increment);
+	void ODESolver(Gillespy::Simulation<double> *simulation, double increment, SolverConfiguration config);
 }

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
@@ -297,10 +297,6 @@ namespace Gillespy
 			{
 				LOOP_OVER_INTEGRATE = 1,
 			};
-
-			double rtol = 1e-9;
-			double atol = 1e-12;
-			double max_step = 0.25;
 		};
 
 		std::set<int> flag_det_rxns(

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/HybridModel.h
@@ -25,9 +25,6 @@
 #include <queue>
 #include <list>
 
-#define GPY_HYBRID_ABSTOL 1e-8
-#define GPY_HYBRID_RELTOL 1e-8
-
 namespace Gillespy
 {
 	namespace TauHybrid
@@ -300,6 +297,10 @@ namespace Gillespy
 			{
 				LOOP_OVER_INTEGRATE = 1,
 			};
+
+			double rtol = 1e-9;
+			double atol = 1e-12;
+			double max_step = 0.25;
 		};
 
 		std::set<int> flag_det_rxns(

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
@@ -63,9 +63,6 @@ int main(int argc, char* argv[])
 	simulation.number_timesteps = number_timesteps;
 	simulation.number_trajectories = number_trajectories;
 	simulation.output_interval = parser.output_interval;
-	simulation.rtol = parser.rtol;
-	simulation.atol = parser.atol;
-	simulation.max_step = parser.max_step;
 	init_simulation(&model, simulation);
 	Gillespy::TauHybrid::map_species_modes(simulation.species_state);
 	Gillespy::TauHybrid::map_rate_rules(simulation.species_state);
@@ -76,7 +73,14 @@ int main(int argc, char* argv[])
 	if (parser.verbose)
 		logger.set_log_level(LogLevel::INFO);
 
-	TauHybrid::TauHybridCSolver(&simulation, events, tau_tol, logger);
+	// Configure solver options from command-line arguments (or defaults)
+	SolverConfiguration config = {
+		parser.rtol,
+		parser.atol,
+		parser.max_step,
+	};
+
+	TauHybrid::TauHybridCSolver(&simulation, events, logger, tau_tol, config);
 	simulation.output_buffer_final(std::cout);
 	return simulation.get_status();
 }

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSimulation.cpp
@@ -63,6 +63,9 @@ int main(int argc, char* argv[])
 	simulation.number_timesteps = number_timesteps;
 	simulation.number_trajectories = number_trajectories;
 	simulation.output_interval = parser.output_interval;
+	simulation.rtol = parser.rtol;
+	simulation.atol = parser.atol;
+	simulation.max_step = parser.max_step;
 	init_simulation(&model, simulation);
 	Gillespy::TauHybrid::map_species_modes(simulation.species_state);
 	Gillespy::TauHybrid::map_rate_rules(simulation.species_state);

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -77,7 +77,7 @@ namespace Gillespy
 			{
 				y = y0;
 			}
-			Integrator sol(simulation, y, GPY_HYBRID_RELTOL, GPY_HYBRID_ABSTOL);
+			Integrator sol(simulation, y, simulation->rtol, simulation->atol);
 			if (logger.get_log_level() == LogLevel::CRIT)
 			{
 				sol.set_error_handler(silent_error_handler);

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.cpp
@@ -86,6 +86,16 @@ namespace Gillespy
 				sol.set_error_handler(silent_error_handler);
 			}
 
+			// Configure user-specified solver tolerances.
+			if (!sol.configure(config))
+			{
+				logger.warn() << "Received invalid tolerances: {"
+					<< "rtol = " << config.rel_tol
+					<< ", atol = " << config.abs_tol
+					<< ", max_step = " << config.max_step
+					<< "}" << std::endl;
+			}
+
 			// Tau selector initialization. Used to select a valid tau step.
 			TauArgs<double> tau_args = initialize(model, tau_tol);
 

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/TauHybridSolver.h
@@ -25,6 +25,6 @@ namespace Gillespy
 {
 	namespace TauHybrid
 	{
-    	void TauHybridCSolver(HybridSimulation* simulation, std::vector<Event> &events, double tau_tol, Logger &logger);
+    	void TauHybridCSolver(HybridSimulation* simulation, std::vector<Event> &events, Logger &logger, double tau_tol, SolverConfiguration config);
 	}
 }

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.cpp
@@ -217,6 +217,14 @@ void Integrator::set_error_handler(CVErrHandlerFn error_handler)
 	validate(this, CVodeSetErrHandlerFn(cvode_mem, error_handler, nullptr));
 }
 
+bool Integrator::configure(SolverConfiguration config)
+{
+	return (
+		validate(this, CVodeSStolerances(cvode_mem, config.rel_tol, config.abs_tol))
+		&& validate(this, CVodeSetMaxStep(cvode_mem, config.max_step))
+	);
+}
+
 URNGenerator::URNGenerator(unsigned long long seed)
 	: uniform(0, 1),
 	  rng(seed)

--- a/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
+++ b/gillespy2/solvers/cpp/c_base/tau_hybrid_cpp_solver/integrator.h
@@ -151,6 +151,10 @@ namespace Gillespy
 		/// and the underlying SBML event data and reaction data are removed.
 		bool disable_root_finder();
 
+		/// @brief Configures CVODE to use the user-supplied configuration data.
+		/// If all configurations were applied successfully, returns true. Otherwise, returns false.
+		bool configure(SolverConfiguration config);
+
 		void set_error_handler(CVErrHandlerFn error_handler);
 
 		IntegrationResults integrate(double *t);

--- a/gillespy2/solvers/cpp/ode_c_solver.py
+++ b/gillespy2/solvers/cpp/ode_c_solver.py
@@ -27,6 +27,14 @@ class ODECSolver(GillesPySolver, CSolver):
     name = "ODECSolver"
     target = "ode"
 
+    @staticmethod
+    def get_supported_integrator_options():
+        return {
+            "rtol",
+            "atol",
+            "max_step",
+        }
+
     def get_solver_settings(self):
         """
         :returns: Tuple of strings, denoting all keyword argument for this solvers run() method.
@@ -35,7 +43,7 @@ class ODECSolver(GillesPySolver, CSolver):
 
     def run(self=None, model: Model = None, t: int = None, number_of_trajectories: int = 1, timeout: int = 0,
             increment: int = None, seed: int = None, debug: bool = False, profile: bool = False, variables={},
-            resume=None, live_output: str = None, live_output_options: dict = {}, **kwargs):
+            resume=None, live_output: str = None, live_output_options: dict = {}, integrator_options: "dict[str, float]" = None, **kwargs):
 
         from gillespy2 import log
 
@@ -98,6 +106,9 @@ class ODECSolver(GillesPySolver, CSolver):
                 "init_pop": populations,
                 "parameters": parameter_values
             })
+        if integrator_options is not None:
+            integrator_options = ODECSolver.validate_integrator_options(integrator_options)
+            args.update(integrator_options)
 
         seed = self._validate_seed(seed)
         if seed is not None:

--- a/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
+++ b/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
@@ -5,6 +5,7 @@ from gillespy2.solvers.utilities import solverutils as cutils
 from gillespy2.core import GillesPySolver, Model, Event, RateRule
 from gillespy2.core.gillespyError import *
 from typing import Union
+from typing import Set
 from enum import IntEnum
 from gillespy2.core import Results
 
@@ -153,6 +154,10 @@ class TauHybridCSolver(GillesPySolver, CSolver):
             RateRule,
         }
 
+    @classmethod
+    def get_supported_integrator_options(cls) -> "Set[str]":
+        return { "rtol", "atol", "max_step" }
+
     def _build(self, model: "Union[Model, SanitizedModel]", simulation_name: str, variable: bool, debug: bool = False,
                custom_definitions=None) -> str:
         variable = variable or len(model.listOfEvents) > 0
@@ -174,7 +179,7 @@ class TauHybridCSolver(GillesPySolver, CSolver):
 
     def run(self=None, model: Model = None, t: int = None, number_of_trajectories: int = 1, timeout: int = 0,
             increment: int = None, seed: int = None, debug: bool = False, profile: bool = False, variables={},
-            resume=None, live_output: str = None, live_output_options: dict = {}, tau_step: int = .03, tau_tol=0.03, **kwargs):
+            resume=None, live_output: str = None, live_output_options: dict = {}, tau_step: int = .03, tau_tol=0.03, integrator_options: "dict[str, float]" = None, **kwargs):
 
         from gillespy2 import log
 
@@ -237,6 +242,9 @@ class TauHybridCSolver(GillesPySolver, CSolver):
                 "init_pop": populations,
                 "parameters": parameter_values
             })
+        if integrator_options is not None:
+            integrator_options = TauHybridCSolver.validate_integrator_options(integrator_options)
+            args.update(integrator_options)
 
         seed = self._validate_seed(seed)
         if seed is not None:
@@ -259,6 +267,7 @@ class TauHybridCSolver(GillesPySolver, CSolver):
         decoder = IterativeSimDecoder.create_default(number_of_trajectories, number_timesteps, len(self.model.listOfSpecies))
 
         sim_exec = self._build(self.model, self.target, self.variable, False)
+        print(args)
         sim_status = self._run(sim_exec, args, decoder, timeout, display_args)
         trajectories, time_stopped = decoder.get_output()
 

--- a/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
+++ b/gillespy2/solvers/cpp/tau_hybrid_c_solver.py
@@ -267,7 +267,6 @@ class TauHybridCSolver(GillesPySolver, CSolver):
         decoder = IterativeSimDecoder.create_default(number_of_trajectories, number_timesteps, len(self.model.listOfSpecies))
 
         sim_exec = self._build(self.model, self.target, self.variable, False)
-        print(args)
         sim_status = self._run(sim_exec, args, decoder, timeout, display_args)
         trajectories, time_stopped = decoder.get_output()
 

--- a/test/test_c_solver_integrators.py
+++ b/test/test_c_solver_integrators.py
@@ -1,0 +1,41 @@
+import unittest
+from gillespy2 import log
+from gillespy2 import TauHybridCSolver
+from gillespy2 import ODECSolver
+from example_models import MichaelisMenten
+
+class TestCSolverIntegrators(unittest.TestCase):
+    """
+    Test cases for ensuring that solvers with a dependency on SUNDIALS/CVODE integrators are configured correctly.
+    """
+
+    integrator_solvers = [
+        TauHybridCSolver,
+        ODECSolver,
+    ]
+    test_model = MichaelisMenten()
+
+    @classmethod
+    def setUpClass(cls):
+        cls.integrator_solvers = [
+            solver_class(model=cls.test_model) for solver_class in cls.integrator_solvers
+        ]
+
+    @unittest.expectedFailure
+    def test_tolerance_options_accepted(self):
+        """
+        Ensure that passing --rtol, --atol, etc. as integrator options is validated successfully.
+        """
+        integrator_options = {
+            "rtol": 1e-4,
+            "atol": 1e-4,
+            "max_step": 1000,
+        }
+        for solver in self.integrator_solvers:
+            with self.subTest(solver=solver.name), \
+                    self.assertRaises(AssertionError, msg="Logger unexpectedly invoked when integrator_options passed"), \
+                    self.assertLogs(log):
+                solver.run(t=1, integrator_options=integrator_options)
+
+if __name__ == "__main__":
+    unittest.main(TestCSolverIntegrators)

--- a/test/test_c_solver_integrators.py
+++ b/test/test_c_solver_integrators.py
@@ -21,7 +21,6 @@ class TestCSolverIntegrators(unittest.TestCase):
             solver_class(model=cls.test_model) for solver_class in cls.integrator_solvers
         ]
 
-    @unittest.expectedFailure
     def test_tolerance_options_accepted(self):
         """
         Ensure that passing --rtol, --atol, etc. as integrator options is validated successfully.


### PR DESCRIPTION
Implements support for CVODE integrator options in C++ solvers, as well as implementing a more extensible approach for validating and modifying supported integrator options for each solver.

Each solver may "declare" which integrator options they support by overriding the `GillesPySolver.get_supported_integrator_options` class method and returning a set of supported options.

# Changes
- `TauHybridCSolver#run` and `ODECSolver#run` now support `integrator_options` as an argument
  - Supports `rtol`, `atol`, and `max_step` as options
# Fixes
- Added reset to integration guard

Closes #730 