### PR TITLE
Pause/Resume test case refactor

### DIFF
--- a/test/pause_model.py
+++ b/test/pause_model.py
@@ -21,6 +21,7 @@ import numpy as np
 from gillespy2 import NumPySSASolver
 from gillespy2 import TauLeapingSolver
 from gillespy2 import ODESolver
+from gillespy2 import TauHybridSolver
 import sys
 np.set_printoptions(suppress=True)
 
@@ -73,14 +74,20 @@ class Oregonator(Model):
         else:
             self.timespan(np.linspace(0, 5, 500001))
 
-model = Oregonator()
-if sys.argv[1] == 'NumPySSASolver':
-    results = model.run(solver=NumPySSASolver(model=model))
-elif sys.argv[1] == 'TauLeapingSolver':
-    results = model.run(solver=TauLeapingSolver(model=model))
-else:
-    results = model.run(solver=ODESolver(model=model))
+def make_solver(which_solver: str, model: Model):
+    solver_dict = {solver.name: solver for solver in [
+        NumPySSASolver,
+        TauLeapingSolver,
+        ODESolver,
+        TauHybridSolver,
+    ]}
+    solver_class = solver_dict.get(which_solver)
+    return solver_class(model=model)
 
-print(results.to_array()[0][-1][0])
+def run_test(which_solver: str):
+    solver = make_solver(which_solver, model=Oregonator())
+    results = solver.run()
+    print(results.to_array()[0][-1][0])
 
-
+if __name__ == "__main__":
+    run_test(sys.argv[1])

--- a/test/test_pause_resume.py
+++ b/test/test_pause_resume.py
@@ -17,14 +17,18 @@
 import unittest
 import numpy as np
 import subprocess
-from shutil import which
+import sys
 from example_models import MichaelisMenten, Oregonator
 from gillespy2.core.results import Results, Trajectory
 from gillespy2.core import Species
-from gillespy2 import SSACSolver
-from gillespy2 import ODESolver
 from gillespy2 import NumPySSASolver
+from gillespy2 import ODESolver
 from gillespy2 import TauLeapingSolver
+from gillespy2 import TauHybridSolver
+from gillespy2 import SSACSolver
+from gillespy2 import ODECSolver
+from gillespy2 import TauLeapingCSolver
+from gillespy2 import TauHybridCSolver
 from gillespy2.core import gillespyError
 import subprocess
 import signal
@@ -33,82 +37,94 @@ import os
 
 
 class TestPauseResume(unittest.TestCase):
-    solvers = [SSACSolver, ODESolver, NumPySSASolver, TauLeapingSolver]
+    py_solvers = [
+        ODESolver,
+        NumPySSASolver,
+        TauLeapingSolver,
+        # TauHybridSolver,
+    ]
+    c_solvers = [
+        SSACSolver,
+        ODECSolver,
+        # TauLeapingCSolver,
+        # TauHybridCSolver,
+    ]
+    solvers = [
+        *py_solvers,
+        *c_solvers,
+    ]
 
     model = MichaelisMenten()
-    for sp in model.listOfSpecies.values():
-        sp.mode = 'discrete'
     labeled_results = {}
     labeled_results_more_trajectories = {}
 
-
-    for solver in solvers:
-        solver = solver(model=model)
-        labeled_results[solver.name] = model.run(solver=solver, show_labels=True)
+    def setUpClass():
+        for sp in TestPauseResume.model.listOfSpecies.values():
+            sp.mode = 'discrete'
+        for solver in TestPauseResume.solvers:
+            solver = solver(model=TestPauseResume.model)
+            TestPauseResume.labeled_results[solver.name] = solver.run()
 
     def test_altered_model_failure(self):
         model = MichaelisMenten()
         for solver_class in self.solvers:
-            solver = solver_class(model=model)
-            tmpResults = model.run(solver=solver)
-            with self.assertRaises(gillespyError.SimulationError):
-                sp1 = Species('sp2',initial_value=5)
-                model.add_species(sp1)
+            with self.subTest(solver=solver_class.name):
                 solver = solver_class(model=model)
-                tmpResults = model.run(solver=solver,resume=tmpResults,t=150)
-            model.delete_species('sp2')
-
+                tmpResults = model.run(solver=solver)
+                with self.assertRaises(gillespyError.SimulationError):
+                    sp1 = Species('sp2',initial_value=5)
+                    model.add_species(sp1)
+                    solver = solver_class(model=model)
+                    tmpResults = model.run(solver=solver,resume=tmpResults,t=150)
+                model.delete_species('sp2')
 
     def test_resume(self):
         model = self.model
         for solver in self.solvers:
             solver = solver(model=model)
             self.labeled_results[solver.name] = model.run(solver=solver, show_labels=True,
-                                                     resume=self.labeled_results[solver.name], t=150)
+                                                    resume=self.labeled_results[solver.name], t=150)
         for solver in self.solvers:
-            self.assertEqual(int(self.labeled_results[solver.name][0]['time'][-1]),150)
+            with self.subTest(solver=solver.name):
+                self.assertEqual(int(self.labeled_results[solver.name][0]['time'][-1]),150)
 
     def test_time_fail(self):
         model = self.model
         for solver in self.solvers:
-            with self.assertRaises((gillespyError.ExecutionError, gillespyError.SimulationError)):
+            with self.subTest(solver=solver.name), self.assertRaises((gillespyError.ExecutionError, gillespyError.SimulationError)):
                 solver = solver(model=model)
                 self.labeled_results = model.run(solver=solver, show_labels=True, resume=self.labeled_results[solver.name],
                                                  t=1)
 
     def test_pause(self):
-        py_path = which('python3')
-        if py_path is None:
-            py_path = which('python')
-        model_path = os.path.join(os.path.dirname(__file__), 'pause_model.py')
-        args = [[py_path, model_path, 'NumPySSASolver'],
-                [py_path, model_path, 'TauLeapingSolver'],
-                [py_path, model_path, 'ODESolver']]
-        for arg in args:
-            if os.name == 'nt':
-                p = subprocess.Popen(arg, stdout=subprocess.PIPE, creationflags=subprocess.CREATE_NEW_PROCESS_GROUP)
-                time.sleep(2)
-                p.send_signal(signal.CTRL_BREAK_EVENT)
+        def try_solver_time(solver_name):
+            if os.name == "nt":
+                popen_args = { "creationflags": subprocess.CREATE_NEW_PROCESS_GROUP }
+                oskill = lambda proc: proc.send_signal(signal.CTRL_BREAK_EVENT)
             else:
-                p = subprocess.Popen(arg, start_new_session=True, stdout=subprocess.PIPE)
+                popen_args = { "start_new_session": True }
+                oskill = lambda proc: os.kill(proc.pid, signal.SIGINT)
+            with subprocess.Popen([sys.executable, model_path, solver_name], stdout=subprocess.PIPE, **popen_args) as p:
                 time.sleep(2)
-                os.kill(p.pid, signal.SIGINT)
-            out, err = p.communicate()
-            # End time for Oregonator is 5. If indexing into a numpy array using the form:
-            # results[0][-1][0] (where .run(show_labels=False), this index being the last time in the index
-            # One would get an output of "5.0" before converting it to an int. Hence, assert time != 5.0 rather than 5.
-            self.assertFalse(out.decode('utf-8').rstrip() == '5.0')
+                oskill(p)
+                out, err = p.communicate()
+                if p.returncode != 0:
+                    self.fail(f"Returned status code: {p.returncode}")
+                return out.decode("utf-8").rstrip()
 
-        solvers = [SSACSolver]
+        model_path = os.path.join(os.path.dirname(__file__), 'pause_model.py')
+        solvers = [solver.name for solver in self.py_solvers]
+        for solver_name in solvers:
+            with self.subTest("Send SIGINT to external process", solver=solver_name):
+                self.assertNotEqual(try_solver_time(solver_name), "5.0")
+
+    def test_timeout(self):
         # For the C solvers, timeouts behave identical to a keyboard interrupt, and would return the same data, if
         # one was to KeyBoardInterrupt, at the same time a timeout ended. This is because timeouts in C solvers
         # and KeyBoardInterrupt send the same signal to the subprocess, the only difference is KeyBoardInterrupt is
         # manual, whereas timeout is a set variable
-        for solver in solvers:
-            model = Oregonator()
-            solver = solver(model=model)
-            results = model.run(solver=solver, timeout=1)
-            self.assertFalse(results.to_array()[0][-1][0] == '5.0')
-
-
-
+        for solver in self.solvers:
+            with self.subTest("Test result of keyboard interrupt for solver", solver=solver.name):
+                solver = solver(model=self.model)
+                results = solver.run(timeout=1)
+                self.assertFalse(results.to_array()[0][-1][0] == '5.0')


### PR DESCRIPTION
Update the test case in `test/test_pause_resume.py` to be more readable and to include additional solvers.

# Changes
- Delegate script `pause_model.py` in test suite supports additional solvers
- `test_pause_resume.py` now executes test simulation in `setUpClass` method instead of globally
- `test_pause_resume.py` supports additional solvers
- `test_pause_resume.py` resolves python from the current script's executable rather than manually resolving to `python3` or `python`