### PR TITLE
Downgrade MinGW in all GHA workflows

### DIFF
--- a/.github/workflows/run-full-tests.yml
+++ b/.github/workflows/run-full-tests.yml
@@ -21,6 +21,16 @@ jobs:
       with:
         python-version: ${{ matrix.python-versions }}
 
+    # see: https://github.com/actions/virtual-environments/pull/5729
+    # GHA recently upgrading MinGW to v11.20, which seems to break things in that environment.
+    # Until this issue can be addressed, downgrade to the previous known working version, v8.1.0.
+    - name: Initialize MinGW dependencies
+      run: |
+        choco install make
+        choco uninstall mingw
+        choco install mingw --version 8.1.0 --force
+      if: matrix.os == 'windows-latest'
+
     - name: Install Python dependencies
       run: | 
         python -m pip install --upgrade pip

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -18,6 +18,16 @@ jobs:
       with:
         python-version: '3.7'
 
+    # see: https://github.com/actions/virtual-environments/pull/5729
+    # GHA recently upgrading MinGW to v11.20, which seems to break things in that environment.
+    # Until this issue can be addressed, downgrade to the previous known working version, v8.1.0.
+    - name: Initialize MinGW dependencies
+      run: |
+        choco install make
+        choco uninstall mingw
+        choco install mingw --version 8.1.0 --force
+      if: matrix.os == 'windows-latest'
+
     - name: Install Python dependencies
       run: | 
         python -m pip install --upgrade pip

--- a/.github/workflows/run-system-tests.yml
+++ b/.github/workflows/run-system-tests.yml
@@ -20,6 +20,16 @@ jobs:
       with:
         python-version: '3.7'
 
+    # see: https://github.com/actions/virtual-environments/pull/5729
+    # GHA recently upgrading MinGW to v11.20, which seems to break things in that environment.
+    # Until this issue can be addressed, downgrade to the previous known working version, v8.1.0.
+    - name: Initialize MinGW dependencies
+      run: |
+        choco install make
+        choco uninstall mingw
+        choco install mingw --version 8.1.0 --force
+      if: matrix.os == 'windows-latest'
+
     - name: Install Python dependencies
       run: | 
         python -m pip install --upgrade pip

--- a/.github/workflows/run-unit-tests.yml
+++ b/.github/workflows/run-unit-tests.yml
@@ -18,6 +18,16 @@ jobs:
       with:
         python-version: '3.7'
 
+    # see: https://github.com/actions/virtual-environments/pull/5729
+    # GHA recently upgrading MinGW to v11.20, which seems to break things in that environment.
+    # Until this issue can be addressed, downgrade to the previous known working version, v8.1.0.
+    - name: Initialize MinGW dependencies
+      run: |
+        choco install make
+        choco uninstall mingw
+        choco install mingw --version 8.1.0 --force
+      if: matrix.os == 'windows-latest'
+
     - name: Install Python dependencies
       run: | 
         python -m pip install --upgrade pip


### PR DESCRIPTION
Fix GitHub Actions failures on Windows, caused by a missing import from MinGW's C++ runtime libraries. This is probably due to misconfigured environment paths, conflicting MinGW versions, or a similar issue on GitHub's end.

For now, the fix is to downgrade to the previous version of MinGW. Long-term solutions include manually reconfiguring GHA's environment paths, including the required C++ runtime libraries manually, or statically linking against the C++ runtime. For more information, see: https://github.com/actions/virtual-environments/pull/5729