### PR TITLE
Delete `name` from EventAssignment when anonymizing

### DIFF
--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -66,6 +66,7 @@ class EventAssignment(Jsonify):
             raise EventError(
                 'GillesPy2 Event Assignment variable must be a valid gillespy2 species')
         if not isinstance(self.expression, str):
+            print(self.expression)
             raise EventError(
                              'GillesPy2 Event Assignment expression requires a '
                              'valid string expression')
@@ -73,11 +74,16 @@ class EventAssignment(Jsonify):
     def __str__(self):
         return f"{self.variable}: {self.expression}"
 
-    def __getattribute__(self, key):
+    def __getattr__(self, key):
         if key == 'name':
             from gillespy2.core import log
             log.warning('EventAssignment.name has been deprecated.')
             return self.__name_deprecated
+            # return EventAssignment.__getattribute__(self, '__name_deprecated')
+        # else: 
+        #     return EventAssignment.__getattribute__(self, key)
+        # else:
+        #     return self.__getattr__(key)
 
 class EventTrigger(Jsonify):
     """

--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -16,7 +16,6 @@
 
 import uuid
 
-from gillespy2.core import log
 from gillespy2.core.gillespyError import *
 from gillespy2.core.jsonify import Jsonify
 
@@ -40,11 +39,13 @@ class EventAssignment(Jsonify):
 
     """
 
+    
     def __init__(self, name=None, variable=None, expression=None):
 
         if name in (None, ""):
             name = f'evn{uuid.uuid4()}'.replace('-', '_')
         else:
+            from gillespy2.core import log
             log.warning("EventAssignment.name has been deprecated.")
         self.__name_deprecated = name
 
@@ -74,6 +75,7 @@ class EventAssignment(Jsonify):
 
     def __getattr__(self, key):
         if key == 'name':
+            from gillespy2.core import log
             log.warning('EventAssignment.name has been deprecated.')
             return self.__name_deprecated
 

--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -66,7 +66,6 @@ class EventAssignment(Jsonify):
             raise EventError(
                 'GillesPy2 Event Assignment variable must be a valid gillespy2 species')
         if not isinstance(self.expression, str):
-            print(self.expression)
             raise EventError(
                              'GillesPy2 Event Assignment expression requires a '
                              'valid string expression')

--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -16,6 +16,7 @@
 
 import uuid
 
+from gillespy2.core import log
 from gillespy2.core.gillespyError import *
 from gillespy2.core.jsonify import Jsonify
 
@@ -44,7 +45,6 @@ class EventAssignment(Jsonify):
         if name in (None, ""):
             name = f'evn{uuid.uuid4()}'.replace('-', '_')
         else:
-            from gillespy2.core import log
             log.warning("EventAssignment.name has been deprecated.")
         self.__name_deprecated = name
 
@@ -74,7 +74,6 @@ class EventAssignment(Jsonify):
 
     def __getattr__(self, key):
         if key == 'name':
-            from gillespy2.core import log
             log.warning('EventAssignment.name has been deprecated.')
             return self.__name_deprecated
 

--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -79,11 +79,8 @@ class EventAssignment(Jsonify):
             from gillespy2.core import log
             log.warning('EventAssignment.name has been deprecated.')
             return self.__name_deprecated
-            # return EventAssignment.__getattribute__(self, '__name_deprecated')
-        # else: 
-        #     return EventAssignment.__getattribute__(self, key)
-        # else:
-        #     return self.__getattr__(key)
+        else: 
+            raise AttributeError
 
 class EventTrigger(Jsonify):
     """

--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -73,7 +73,7 @@ class EventAssignment(Jsonify):
     def __str__(self):
         return f"{self.variable}: {self.expression}"
 
-    def __getattr__(self, key):
+    def __getattribute__(self, key):
         if key == 'name':
             from gillespy2.core import log
             log.warning('EventAssignment.name has been deprecated.')

--- a/gillespy2/core/events.py
+++ b/gillespy2/core/events.py
@@ -42,9 +42,11 @@ class EventAssignment(Jsonify):
     def __init__(self, name=None, variable=None, expression=None):
 
         if name in (None, ""):
-            self.name = f'evn{uuid.uuid4()}'.replace('-', '_')
+            name = f'evn{uuid.uuid4()}'.replace('-', '_')
         else:
-            self.name = name
+            from gillespy2.core import log
+            log.warning("EventAssignment.name has been deprecated.")
+        self.__name_deprecated = name
 
         self.variable = variable
         self.expression = expression
@@ -69,6 +71,12 @@ class EventAssignment(Jsonify):
 
     def __str__(self):
         return f"{self.variable}: {self.expression}"
+
+    def __getattr__(self, key):
+        if key == 'name':
+            from gillespy2.core import log
+            log.warning('EventAssignment.name has been deprecated.')
+            return self.__name_deprecated
 
 class EventTrigger(Jsonify):
     """

--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -1278,14 +1278,10 @@ class Model(SortableObject, Jsonify):
                 solver = self.get_best_solver_algo(algorithm)
             else:
                 solver = self.get_best_solver()
-            print(solver)
 
         if not hasattr(solver, "is_instantiated"):
             try:
                 sol_kwargs = {'model': self}
-                # print(sol_kwargs)
-                # print(solver)
-                # print(solver.name)
                 if "CSolver" in solver.name and \
                     ("resume" in solver_args or "variables" in solver_args or "live_output" in solver_args):
                     sol_kwargs['variable'] = True

--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -1062,6 +1062,9 @@ class Model(SortableObject, Jsonify):
         assignments = self.listOfAssignmentRules.values()
         rates = self.listOfRateRules.values()
         events = self.listOfEvents.values()
+        for event in events:
+            for assignment in event.__dict__['assignments']:
+                del assignment.__dict__['name']
         functions = self.listOfFunctionDefinitions.values()
 
         # A translation table is used to anonymize user-defined variable names and formulas into generic counterparts.

--- a/gillespy2/core/model.py
+++ b/gillespy2/core/model.py
@@ -1064,7 +1064,7 @@ class Model(SortableObject, Jsonify):
         events = self.listOfEvents.values()
         for event in events:
             for assignment in event.__dict__['assignments']:
-                del assignment.__dict__['name']
+                del assignment.__dict__['__name_deprecated']
         functions = self.listOfFunctionDefinitions.values()
 
         # A translation table is used to anonymize user-defined variable names and formulas into generic counterparts.
@@ -1278,10 +1278,14 @@ class Model(SortableObject, Jsonify):
                 solver = self.get_best_solver_algo(algorithm)
             else:
                 solver = self.get_best_solver()
+            print(solver)
 
         if not hasattr(solver, "is_instantiated"):
             try:
                 sol_kwargs = {'model': self}
+                # print(sol_kwargs)
+                # print(solver)
+                # print(solver.name)
                 if "CSolver" in solver.name and \
                     ("resume" in solver_args or "variables" in solver_args or "live_output" in solver_args):
                     sol_kwargs['variable'] = True


### PR DESCRIPTION
This will patch the problem with models not hashing correctly, and only edits `make_translation_table()` to avoid breaking gillespy2
- Also adds deprecation warnings for `EventAssignment.name`