### PR TITLE
HOTFIX: Homo-Dimer Reaction Propensities

### DIFF
--- a/gillespy2/core/reaction.py
+++ b/gillespy2/core/reaction.py
@@ -106,18 +106,20 @@ class Reaction(SortableObject, Jsonify):
         if reactants is not None:
             for r in reactants:
                 rtype = type(r).__name__
-                if rtype == 'Species':
-                    self.reactants[r.name] = reactants[r]
+                name = r.name if rtype == 'Species' else r
+                if name in self.reactants:
+                    self.reactants[name] += reactants[r]
                 else:
-                    self.reactants[r] = reactants[r]
+                    self.reactants[name] = reactants[r]
         
         if products is not None:
             for p in products:
-                rtype = type(p).__name__
-                if rtype == 'Species':
-                    self.products[p.name] = products[p]
+                ptype = type(p).__name__
+                name = p.name if ptype == 'Species' else p
+                if name in self.products:
+                    self.products[name] += products[p]
                 else:
-                    self.products[p] = products[p]
+                    self.products[name] = products[p]
             
         if self.marate is not None:
             rtype = type(self.marate).__name__
@@ -365,7 +367,10 @@ class Reaction(SortableObject, Jsonify):
         except TypeError as err:
             raise ReactionError(f"Failed to validate product. Reason given: {err}") from err
 
-        self.products[name] = stoichiometry
+        if name in self.products:
+            self.products[name] += stoichiometry
+        else:
+            self.products[name] = stoichiometry
         
     def addReactant(self, *args, **kwargs):
         """
@@ -404,7 +409,10 @@ class Reaction(SortableObject, Jsonify):
         except TypeError as err:
             raise ReactionError(f"Failed to validate reactant. Reason given: {err}") from err
 
-        self.reactants[name] = stoichiometry
+        if name in self.reactants:
+            self.reactants[name] += stoichiometry
+        else:
+            self.reactants[name] = stoichiometry
         if self.massaction and self.type == "mass-action":
             self._create_mass_action()
 


### PR DESCRIPTION
## Case 1
> This case is impossible to catch since python dictionaries don't support duplicate keys.
```
r1 = gillespy2.Reaction(
    name="r1", reactants={"s1":1, "s1":1}, products={"s1":1, "s2":1}, rate=0.1
)
```
## Case 2
```
S1 = gillespy2.Species(name="s1", initial_value=999)
r2 = gillespy2.Reaction(
    name="r2", reactants={"s1":1, S1:1}, products={"s1":1, "s2":1}, rate=0.1
)
```
### Propensity Bug
```
r2
	Reactants
		s1: 1
	Products
		s1: 1
		s2: 1
	Propensity Function: (0.1*s1)
```
### Fixed Propensity
```
r2
	Reactants
		s1: 2
	Products
		s1: 1
		s2: 1
	Propensity Function: (((0.1*s1)*(s1-1))/vol)
```
## Case 3
```
r3 = gillespy2.Reaction(
    name="r3", reactants={"s1":1}, products={"s1":1, "s2":1}, rate=0.1
)
r3.add_reactant("s1", 1)
```
### Propensity Bug
```
r3
	Reactants
		s1: 1
	Products
		s1: 1
		s2: 1
	Propensity Function: (0.1*s1)
```
### Fixed Propensity
```
r3
	Reactants
		s1: 2
	Products
		s1: 1
		s2: 1
	Propensity Function: (((0.1*s1)*(s1-1))/vol)
```

closes #876 