### PR TITLE
Fix C++ dependency warning

### DIFF
--- a/gillespy2/solvers/cpp/build/build_engine.py
+++ b/gillespy2/solvers/cpp/build/build_engine.py
@@ -18,6 +18,7 @@ import os
 import shutil
 import tempfile
 import platform
+from importlib.util import find_spec
 from pathlib import Path
 from typing import Union
 
@@ -65,8 +66,12 @@ class BuildEngine():
         :returns: A list of missing dependencies.
         """
 
-        dependencies = ["g++", "make"]
+        dependencies = ["g++", "scons"]
         missing = [(dep) for dep in dependencies if shutil.which(dep) is None]
+        # SCons can either be an executable or a Python package
+        # If the executable is not found, default to the Python package
+        if "scons" in missing and find_spec("SCons") is not None:
+            missing.remove("scons")
 
         return missing
 

--- a/gillespy2/solvers/cpp/build/make.py
+++ b/gillespy2/solvers/cpp/build/make.py
@@ -17,11 +17,14 @@
 import os
 import subprocess
 
+from importlib.util import find_spec
 from pathlib import Path
+import shutil
 import sys
 
 from gillespy2.core import log
 from gillespy2.core import gillespyError
+from gillespy2.core import BuildError
 
 class Make():
     def __init__(self, makefile: str, output_dir: str, obj_dir: str = None, template_dir: str = None):
@@ -58,6 +61,15 @@ class Make():
 
         self.output_file = Path(self.output_dir, self.output_file)
 
+        # SCons can either be an executable or a Python package.
+        scons_exe = shutil.which("scons")
+        if scons_exe is None:
+            self.scons_cmd = [str(Path(sys.executable).resolve()), "-m", "SCons"]
+        elif find_spec("SCons") is not None:
+            self.scons_cmd = [str(Path(scons_exe).resolve())]
+        else:
+            raise BuildError("SCons must be installed in order to compile solver with C++")
+
     def prebuild(self):
         self.__execute("build")
 
@@ -82,8 +94,7 @@ class Make():
         make_args = [(f"{key.upper()}={value}") for key, value in args_dict.items()]
 
         # Create the make command.
-        scons_cmd = [str(Path(sys.executable).resolve()), "-m", "SCons"]
-        make_cmd = [*scons_cmd, f"-C{str(self.output_dir.resolve())}", f"-f{str(self.makefile)}"] + make_args
+        make_cmd = [*self.scons_cmd, f"-C{str(self.output_dir.resolve())}", f"-f{str(self.makefile)}"] + make_args
 
         try:
             result = subprocess.run(make_cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/gillespy2/solvers/cpp/c_solver.py
+++ b/gillespy2/solvers/cpp/c_solver.py
@@ -68,7 +68,7 @@ class CSolver:
 
         if len(BuildEngine.get_missing_dependencies()) > 0:
             raise gillespyError.SimulationError(
-                "Please install/configure 'g++' and 'make' on your system, to ensure that GillesPy2 C solvers will run properly."
+                "Please install/configure 'g++' and 'scons' on your system, to ensure that GillesPy2 C solvers will run properly."
             )
 
         if platform.system() == "Windows" and " " in gillespy2.__file__:


### PR DESCRIPTION
Updating the C++ dependency list to look for SCons instead of GNU Make. The process for doing this is a little different from Make, since it's usually a Python package.

# Changes Made
- Removed `make` from the list of C++ dependencies to check for, added `scons`
- Updated `scons` dependency check and call to look for the executable first, defaulting to the Python package if not found
- Updated warning in `CSolver` constructor to reference `scons` instead of `make`

# Testing
Run `test_check_cpp_support` unit test in [test_check_cpp_support.py](https://github.com/StochSS/GillesPy2/blob/fa8988276399263d6bc5ded72fd23ca06eb4e127/test/test_check_cpp_support.py#L28) or any explicit C++ solver test with:
- SCons installed as a Python package, e.g. `python3 -m pip install scons` (should build and run successfully)
- SCons installed externally, e.g. via a package manager or from [the SCons download page](https://scons.org/pages/download.html) (should build and run successfully)
- SCons not installed at all (should fail with the correct warning message)

---
Fixes #923 